### PR TITLE
fix(query): surface plain-text error responses from InfluxDB Core

### DIFF
--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -179,6 +179,7 @@ export class QueryService {
   private handleQueryError(error: any): never {
     const errorMessage =
       error.response?.data?.error ||
+      (typeof error.response?.data === "string" ? error.response.data : null) ||
       error.response?.statusText ||
       error.message;
     const statusCode = error.response?.status;


### PR DESCRIPTION
## Summary

- InfluxDB v3 Core returns query errors as plain strings in the HTTP response body, not as JSON objects with an `error` field
- `handleQueryError` only checked `response.data.error`, so these plain-text errors fell through to `statusText`, producing generic "Internal Server Error" messages
- Added a fallback to extract the message when `response.data` is a string

## Test plan

- [x] Run a malformed query against a Core instance and verify the actual InfluxDB error message is returned instead of "Internal Server Error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)