### PR TITLE
Add e2e test suite with MCP protocol compliance tests

### DIFF
--- a/.claude/skills/build-run-core-enterprise/SKILL.md
+++ b/.claude/skills/build-run-core-enterprise/SKILL.md
@@ -18,7 +18,7 @@ InfluxDB 3 Core or Enterprise instances.
 
 ## Prerequisites
 
-- Node.js v18+ and npm v9+
+- Node.js and npm (see `engines` in `package.json` for minimum version)
 - A running InfluxDB 3 Core or Enterprise instance (default port: `8181`).
   When running both Core and Enterprise on the same host for testing, each
   needs a distinct port (e.g., Core on `8181`, Enterprise on `8281`).

--- a/.claude/skills/build-run-core-enterprise/SKILL.md
+++ b/.claude/skills/build-run-core-enterprise/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: Build & Run (Core/Enterprise)
+description: >-
+  This skill should be used when the user asks to "build the MCP server",
+  "run the server", "set up for InfluxDB Core", "set up for InfluxDB Enterprise",
+  "configure the server", "start the MCP server", "run with Docker",
+  "test the MCP server connection", "use the MCP inspector",
+  "set up .env", "what npm commands are available",
+  or needs to build, configure, run, or troubleshoot this MCP server against
+  InfluxDB 3 Core or InfluxDB 3 Enterprise.
+version: 0.1.0
+---
+
+# Build & Run: InfluxDB 3 Core / Enterprise
+
+Workflow for building, configuring, and running the InfluxDB MCP server against
+InfluxDB 3 Core or Enterprise instances.
+
+## Prerequisites
+
+- Node.js v18+ and npm v9+
+- A running InfluxDB 3 Core or Enterprise instance (default port: `8181`).
+  When running both Core and Enterprise on the same host for testing, each
+  needs a distinct port (e.g., Core on `8181`, Enterprise on `8281`).
+- An InfluxDB auth token (operator, admin, or resource token)
+
+## Environment Setup
+
+Create a `.env` file in the project root (or set env vars directly). Three
+variables are required:
+
+```env
+INFLUX_DB_INSTANCE_URL=http://localhost:8181/
+INFLUX_DB_TOKEN=<your_token>
+INFLUX_DB_PRODUCT_TYPE=core
+```
+
+Set `INFLUX_DB_PRODUCT_TYPE` to `core` or `enterprise`. The server behavior is
+identical for both; the type controls which tools are advertised and how
+config validation works.
+
+Copy `env.example` as a starting point: `cp env.example .env`
+
+### Token types (Core/Enterprise)
+
+| Token Type | Purpose | How to obtain |
+|---|---|---|
+| Operator | Full admin, bootstraps the instance | Printed on first `influxdb3 serve` start |
+| Admin | Full admin except managing other admins | Created via `create_admin_token` tool |
+| Resource | Scoped read/write on specific databases | Created via `create_resource_token` tool |
+
+Use the operator token during initial setup. Create scoped resource tokens for
+applications.
+
+## Build & Run
+
+```bash
+npm install        # install dependencies
+npm run build      # compile TypeScript → build/
+npm start          # run the server (requires build/)
+npm run dev        # build + run in one step
+```
+
+The server communicates over stdio (stdin/stdout). All diagnostic output goes
+to stderr. Do not use `console.log` — it would corrupt the MCP transport.
+
+### Verify the server starts
+
+```bash
+npm run dev 2>&1 | head -5
+```
+
+Look for: `[MCP] Server initialized with N tools, N resources, N prompts`
+
+## Docker Workflow
+
+Build and run via Docker when isolating the server from the host environment
+or deploying remotely.
+
+```bash
+npm run docker:build    # build Docker image
+npm run docker:up       # start (reads .env file)
+npm run docker:down     # stop
+npm run docker:logs     # tail logs
+```
+
+When InfluxDB runs on the host machine, use `host.docker.internal` as the
+hostname in `.env`:
+
+```env
+INFLUX_DB_INSTANCE_URL=http://host.docker.internal:8181/
+INFLUX_DB_TOKEN=<your_token>
+INFLUX_DB_PRODUCT_TYPE=enterprise
+```
+
+For MCP client configuration examples (local, Docker, npx), see
+`.claude/skills/build-run-core-enterprise/references/mcp-client-configs.md`.
+
+## Testing with the MCP Inspector
+
+The MCP Inspector provides an interactive UI for testing tool calls:
+
+```bash
+npm run "MCP inspector"   # quotes required (space in script name)
+```
+
+This launches the inspector connected to the built server. Use it to:
+- Call `health_check` to verify connectivity
+- Call `list_databases` to confirm data access
+- Test `execute_query` with a simple SQL query
+
+## Available Tools (Core/Enterprise)
+
+All tools available for Core/Enterprise instances:
+
+| Tool | Description |
+|---|---|
+| `health_check` | Verify connection and health status |
+| `list_databases` | List all databases |
+| `create_database` | Create a new database |
+| `delete_database` | Delete a database |
+| `execute_query` | Run SQL queries |
+| `get_measurements` | List tables in a database |
+| `get_measurement_schema` | Show columns/types for a table |
+| `write_line_protocol` | Write data via line protocol |
+| `create_admin_token` | Create named admin token |
+| `list_admin_tokens` | List admin tokens |
+| `create_resource_token` | Create scoped resource token |
+| `list_resource_tokens` | List resource tokens |
+| `delete_token` | Delete a token by name |
+| `regenerate_operator_token` | Regenerate operator token (destructive) |
+| `get_help` | Built-in help and troubleshooting |
+| `load_database_context` | Load custom context from `context/` |
+
+Tools like `update_database` and `cloud_*` token tools are **not** available
+for Core/Enterprise.
+
+## Troubleshooting
+
+### "Configuration validation failed"
+
+Missing or invalid env vars. Verify `.env` has all three required variables
+and `INFLUX_DB_PRODUCT_TYPE` is exactly `core` or `enterprise`.
+
+### Health check fails but server starts
+
+The server can start without a reachable InfluxDB instance. Check:
+1. InfluxDB is running: `curl http://localhost:8181/ping`
+2. Token is valid (operator or admin token for full access)
+3. URL has trailing slash if using the default config
+
+### "No data host configured"
+
+`INFLUX_DB_INSTANCE_URL` is missing or empty. For Core/Enterprise, this must
+be the full URL including protocol and port.
+
+### Port confusion
+
+InfluxDB 3 Core/Enterprise defaults to port `8181`. Some example files in this
+repo reference port `8086` (the InfluxDB 2.x default). Always confirm which
+port the target instance listens on. When running both Core and Enterprise on
+the same host, each must use a different port — update `INFLUX_DB_INSTANCE_URL`
+accordingly for each server instance.
+
+## Additional Resources
+
+### Reference Files
+
+- **`references/mcp-client-configs.md`** — MCP client JSON configs for
+  Claude Desktop, Cursor, and other MCP clients (local, Docker, npx variants)

--- a/.claude/skills/build-run-core-enterprise/references/mcp-client-configs.md
+++ b/.claude/skills/build-run-core-enterprise/references/mcp-client-configs.md
@@ -1,0 +1,113 @@
+# MCP Client Configuration Examples
+
+JSON configs for integrating this server with MCP clients (Claude Desktop,
+Cursor, VS Code, etc.). Replace placeholder values with actual credentials.
+
+## Local (built from source)
+
+After `npm install && npm run build`, point the client at the built entry point:
+
+```json
+{
+  "mcpServers": {
+    "influxdb": {
+      "command": "node",
+      "args": ["/absolute/path/to/build/index.js"],
+      "env": {
+        "INFLUX_DB_INSTANCE_URL": "http://localhost:8181/",
+        "INFLUX_DB_TOKEN": "<YOUR_TOKEN>",
+        "INFLUX_DB_PRODUCT_TYPE": "core"
+      }
+    }
+  }
+}
+```
+
+Replace `/absolute/path/to/` with the actual path to this repository.
+Set `INFLUX_DB_PRODUCT_TYPE` to `core` or `enterprise`.
+
+## NPX (no local build required)
+
+Runs the published npm package directly. Requires the package to be published
+to npm first:
+
+```json
+{
+  "mcpServers": {
+    "influxdb": {
+      "command": "npx",
+      "args": ["-y", "influxdb-mcp-server"],
+      "env": {
+        "INFLUX_DB_INSTANCE_URL": "http://localhost:8181/",
+        "INFLUX_DB_TOKEN": "<YOUR_TOKEN>",
+        "INFLUX_DB_PRODUCT_TYPE": "core"
+      }
+    }
+  }
+}
+```
+
+## Docker (InfluxDB on same host)
+
+Build the image first: `npm run docker:build`
+
+Use `host.docker.internal` to reach InfluxDB running on the Docker host:
+
+```json
+{
+  "mcpServers": {
+    "influxdb": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "--add-host=host.docker.internal:host-gateway",
+        "-e", "INFLUX_DB_INSTANCE_URL",
+        "-e", "INFLUX_DB_TOKEN",
+        "-e", "INFLUX_DB_PRODUCT_TYPE",
+        "influxdb-mcp-server"
+      ],
+      "env": {
+        "INFLUX_DB_INSTANCE_URL": "http://host.docker.internal:8181/",
+        "INFLUX_DB_TOKEN": "<YOUR_TOKEN>",
+        "INFLUX_DB_PRODUCT_TYPE": "enterprise"
+      }
+    }
+  }
+}
+```
+
+## Docker (remote InfluxDB)
+
+When InfluxDB is on a separate host, use the remote URL directly (no
+`--add-host` needed):
+
+```json
+{
+  "mcpServers": {
+    "influxdb": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "INFLUX_DB_INSTANCE_URL",
+        "-e", "INFLUX_DB_TOKEN",
+        "-e", "INFLUX_DB_PRODUCT_TYPE",
+        "influxdb-mcp-server"
+      ],
+      "env": {
+        "INFLUX_DB_INSTANCE_URL": "http://remote-influxdb-host:8181/",
+        "INFLUX_DB_TOKEN": "<YOUR_TOKEN>",
+        "INFLUX_DB_PRODUCT_TYPE": "core"
+      }
+    }
+  }
+}
+```
+
+## Notes
+
+- The `env` block in the MCP client config sets environment variables for the
+  server process. These override any `.env` file.
+- The example `example-*.mcp.json` files in the repo root contain similar
+  configs.
+- Port `8181` is the InfluxDB 3 default. Adjust if your instance uses a
+  different port.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: Testing
+description: >-
+  This skill should be used when the user asks to "run tests", "run the test
+  suite", "check test results", "why are tests failing", "debug test failures",
+  "add a test", "write a test", "update EXPECTED_TOOL_COUNT",
+  "run protocol tests", "run integration tests", "test against InfluxDB",
+  or needs to run, analyze, extend, or troubleshoot the MCP server test suite.
+version: 0.1.0
+---
+
+# Testing the InfluxDB MCP Server
+
+Two-layer test suite using vitest. Protocol tests run without InfluxDB.
+Integration tests require a live instance and are gated behind an env var.
+
+## Prerequisites
+
+Build before testing — tests spawn the compiled `build/index.js`, not source:
+
+```bash
+npm run build
+```
+
+## Running Tests
+
+### Protocol tests (no InfluxDB needed)
+
+```bash
+npm test
+```
+
+Runs `tests/protocol.test.ts` only. Integration tests are skipped
+automatically. Expected runtime: <1 second.
+
+These tests spawn the real server as a child process using the MCP SDK's
+`StdioClientTransport`, perform the `initialize` handshake, and assert on
+protocol responses. No InfluxDB connection is made — protocol requests
+(`tools/list`, `resources/list`, `prompts/list`, `ping`) are answered
+entirely from the server's in-memory registrations.
+
+### Integration tests (live InfluxDB)
+
+```bash
+INFLUX_TEST_ENABLED=true \
+INFLUX_DB_INSTANCE_URL=http://localhost:8181/ \
+INFLUX_DB_TOKEN=<token> \
+INFLUX_DB_PRODUCT_TYPE=core \
+npm run test:integration
+```
+
+Runs `tests/integration.test.ts` against a real InfluxDB 3 Core or Enterprise
+instance. Tests call `health_check`, `list_databases`, and `execute_query`
+through the MCP protocol.
+
+### Watch mode
+
+```bash
+npm run test:watch
+```
+
+Reruns on file changes. Useful during development.
+
+## What the Tests Cover
+
+| Test | What it verifies |
+|---|---|
+| Initialize handshake | Server starts, SDK handshake succeeds, capabilities reported |
+| Server version | Name is `"influxdb-mcp-server"`, version is defined |
+| Tool count | `tools/list` returns exactly `EXPECTED_TOOL_COUNT` tools |
+| Tool structure | Each tool has `name`, `description`, `inputSchema` with `type: "object"` |
+| Core tool names | Spot-checks `health_check`, `execute_query`, `write_line_protocol`, `list_databases`, `create_admin_token` |
+| Resource URIs | 4 resources with correct `influx://` URIs |
+| Resource structure | Each resource has `name`, `uri`, `description` |
+| Prompt names | 3 prompts: `list-databases`, `check-health`, `load-context` |
+| Ping | Server responds to ping |
+| Unknown tool error | Calling nonexistent tool throws `McpError` |
+
+## Analyzing Failures
+
+### `EXPECTED_TOOL_COUNT` mismatch
+
+The most common failure after code changes. The constant in
+`tests/protocol.test.ts` (line 7) must match the actual tool count.
+
+**After adding or removing a tool**, update the constant and comment in
+`tests/protocol.test.ts` (the source of truth). Then update the breakdown
+below for documentation.
+
+To find the current count, start the server briefly and check stderr:
+```bash
+npm run build && INFLUX_DB_INSTANCE_URL=http://localhost:19999/ \
+INFLUX_DB_TOKEN=fake INFLUX_DB_PRODUCT_TYPE=core \
+node build/index.js &
+sleep 1 && kill $!
+```
+
+Look for: `[MCP] Server initialized with N tools, N resources, N prompts`
+
+The tool count breakdown by category file:
+- `help.tools.ts` (2) + `write.tools.ts` (1) + `database.tools.ts` (4)
+- `query.tools.ts` (3) + `token.tools.ts` (6) + `cloud-token.tools.ts` (5)
+- `health.tools.ts` (1) = **22 total**
+- `schema.tools.ts` (4 tools, currently disabled — commented out in
+  `src/tools/index.ts`)
+
+### "build/index.js not found"
+
+Run `npm run build` first. The `tests/setup.ts` guard fails fast with this
+message if the build artifact is missing.
+
+### Initialize handshake timeout
+
+The server process failed to start. Common causes:
+- Build is stale after source changes — rebuild with `npm run build`
+- Missing or invalid env vars — protocol tests use a fake config internally,
+  so this usually means `createTestClient` was called with bad overrides
+
+### Integration test: "HEALTHY" not found
+
+InfluxDB instance is unreachable or unhealthy. Verify:
+1. Instance is running: `curl http://localhost:8181/ping`
+2. Token is valid
+3. `INFLUX_DB_PRODUCT_TYPE` matches the actual instance type
+
+### Two error paths in the server
+
+When diagnosing tool call failures, note the server has two distinct error
+paths (defined in `src/server/index.ts`):
+
+- **Unknown tool name** → `throw new Error(...)` → SDK converts to `McpError`
+  → client sees a rejected promise
+- **Known tool, handler failure** → caught in try/catch → returns
+  `{ content: [{ type: "text", text: "Error: ..." }], isError: true }`
+
+Protocol tests assert the thrown error path. Integration tests assert the
+content-based error path.
+
+## Adding New Tests
+
+### New protocol test
+
+Add to `tests/protocol.test.ts` inside the `describe("MCP protocol compliance")`
+block. Protocol tests use the shared `testClient` from `beforeAll`. No InfluxDB
+is contacted — only test MCP protocol-level behavior.
+
+### New integration test
+
+Add to `tests/integration.test.ts` inside the
+`describe.skipIf(!RUN)("live InfluxDB integration")` block. Call tools via
+`testClient.client.callTool({ name: "...", arguments: {...} })` and assert
+on the response `content[0].text`.
+
+### Test helper
+
+The `createTestClient(env?)` factory in `tests/helpers/mcp-client.ts` spawns
+a real server process and returns a connected MCP `Client`. Override env vars
+by passing a partial record. Always call `close()` in `afterAll`.
+
+## Additional Resources
+
+### Reference Files
+
+- **`.claude/skills/testing/references/test-architecture.md`** — Detailed
+  test architecture, design decisions, and how protocol tests work without
+  InfluxDB

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -41,17 +41,41 @@ entirely from the server's in-memory registrations.
 
 ### Integration tests (live InfluxDB)
 
+Start InfluxDB 3 Core via the provided Docker Compose file:
+
+```bash
+npm run test:infra:up
+```
+
+This starts an ephemeral Core container on port `8181` using a static admin
+token from `tests/fixtures/admin-token.json` (Docker secrets pattern,
+`--object-store memory` — no persistent state).
+
+Run integration tests against it:
+
+```bash
+source env.test.example && npm run test:integration
+```
+
+Tear down when done:
+
+```bash
+npm run test:infra:down
+```
+
+For a custom InfluxDB instance (different port, Enterprise, etc.), set the
+env vars directly instead of sourcing the example file:
+
 ```bash
 INFLUX_TEST_ENABLED=true \
-INFLUX_DB_INSTANCE_URL=http://localhost:8181/ \
-INFLUX_DB_TOKEN=<token> \
-INFLUX_DB_PRODUCT_TYPE=core \
+INFLUX_DB_INSTANCE_URL=http://localhost:8281/ \
+INFLUX_DB_TOKEN=<your_token> \
+INFLUX_DB_PRODUCT_TYPE=enterprise \
 npm run test:integration
 ```
 
-Runs `tests/integration.test.ts` against a real InfluxDB 3 Core or Enterprise
-instance. Tests call `health_check`, `list_databases`, and `execute_query`
-through the MCP protocol.
+Tests call `health_check`, `list_databases`, and `execute_query` through the
+MCP protocol.
 
 ### Watch mode
 

--- a/.claude/skills/testing/references/test-architecture.md
+++ b/.claude/skills/testing/references/test-architecture.md
@@ -1,0 +1,163 @@
+# Test Architecture
+
+## Design Decisions
+
+### Process spawning over in-process testing
+
+The tests spawn `build/index.js` as a child process rather than importing
+`createServer()` directly. Reasons:
+
+1. **`dotenv.config()`** runs at import time in `src/config.ts`, making
+   in-process env manipulation fragile
+2. **Stdio transport initialization** is part of the real startup path —
+   spawning tests the actual entry point
+3. **Dependency breakage** from security patches or version bumps affects
+   the compiled output, not the source. Spawning the built artifact catches
+   these failures.
+
+### Protocol tests need no InfluxDB
+
+The server starts and registers all tools, resources, and prompts in memory
+during `createServer()`. MCP list/ping requests read from these in-memory
+arrays without contacting InfluxDB.
+
+The trick: `createTestClient()` passes a fake config:
+
+```typescript
+const BASE_ENV = {
+  INFLUX_DB_INSTANCE_URL: "http://localhost:19999/",  // nothing listens here
+  INFLUX_DB_TOKEN: "test-token-not-used",
+  INFLUX_DB_PRODUCT_TYPE: "core",
+};
+```
+
+This passes `validateConfig()` (which only checks that the vars exist, not
+that they're reachable). The `InfluxDBClient` constructor succeeds because
+it's lazy — no connection is made until a query or write is executed.
+
+### Tool count as a regression signal
+
+`EXPECTED_TOOL_COUNT` is the primary regression gate for dependency updates.
+When a dependency bump silently breaks a tool import (e.g., a Zod version
+change causes a tool's `zodSchema` definition to fail), the server may
+initialize with fewer tools than expected. The count assertion catches this.
+
+The count also appears in the server's stderr init message:
+`[MCP] Server initialized with N tools, N resources, N prompts`
+
+### Integration tests gated by env var
+
+`describe.skipIf(!process.env.INFLUX_TEST_ENABLED)` ensures integration tests
+never run accidentally. The vitest file is always compiled (catching type
+errors) but executes 0 tests unless the gate is set.
+
+## Test File Responsibilities
+
+### `tests/setup.ts`
+
+Vitest setup file (runs before all tests). Asserts `build/index.js` exists.
+Fails fast with a clear message rather than letting tests produce confusing
+spawn errors.
+
+### `tests/helpers/mcp-client.ts`
+
+Factory function `createTestClient(env?)`:
+
+1. Resolves `build/index.js` path
+2. Creates `StdioClientTransport` with the server command, args, and env
+3. Creates MCP `Client`, calls `connect()` (performs initialize handshake)
+4. Returns `{ client, close }` — the `close()` function terminates the
+   child process
+
+The `stderr: "pipe"` option prevents server diagnostic output from leaking
+into the test runner's stdout.
+
+### `tests/protocol.test.ts`
+
+Single `describe` block with shared `testClient` lifecycle (`beforeAll`/
+`afterAll`). Tests are stateless and order-independent. The server process
+lives for the entire describe block (one spawn per test file, not per test).
+
+Constants at the top of the file serve as the source of truth for expected
+counts and names. Comments document the breakdown so reviewers can verify
+without running the server.
+
+### `tests/integration.test.ts`
+
+Gated `describe` block. Uses the same `createTestClient` factory but with
+real env vars from the shell environment. Tests make actual MCP tool calls
+that hit InfluxDB.
+
+The `execute_query` test is defensive: it first checks if any databases
+exist, and skips gracefully if not (rather than failing on an empty instance).
+
+## vitest Configuration
+
+```typescript
+// vitest.config.ts
+{
+  test: {
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["tests/setup.ts"],
+    testTimeout: 15000,
+    hookTimeout: 15000,
+  }
+}
+```
+
+- **15s timeouts**: Generous for slow CI machines where child process spawn
+  + initialize handshake can take 2-3 seconds
+- **No pool override**: Default vitest forks handle child process spawning
+- **No `rootDir` change to tsconfig**: vitest uses Vite's esbuild pipeline
+  to compile test files independently from `tsc`. The production tsconfig
+  keeps `rootDir: "./src"` which would reject files outside `src/`.
+
+## Adding a New Test Category
+
+To add a new test file (e.g., `tests/write.test.ts`):
+
+1. Create the file with vitest imports
+2. Use `createTestClient()` in `beforeAll`
+3. Call `close()` in `afterAll`
+4. Each test file spawns its own server process — they run in parallel safely
+
+For integration tests that need InfluxDB, use the same
+`describe.skipIf(!process.env.INFLUX_TEST_ENABLED)` gate pattern.
+
+## CI Usage
+
+### Gating dependency updates (Dependabot, Renovate)
+
+Add to the CI workflow:
+
+```yaml
+- run: npm ci
+- run: npm run build
+- run: npm test
+```
+
+The protocol tests verify:
+1. TypeScript compiles with updated deps (build step)
+2. Server process starts without runtime errors (initialize handshake)
+3. MCP SDK client/server are compatible (protocol handshake succeeds)
+4. All tools, resources, and prompts register correctly (count + name checks)
+
+This catches the majority of breaking changes from dependency updates.
+
+### Optional live integration in CI
+
+```yaml
+services:
+  influxdb:
+    image: influxdb3-core:latest
+    ports: ["8181:8181"]
+steps:
+  - run: npm ci && npm run build
+  - run: npm test
+  - run: npm run test:integration
+    env:
+      INFLUX_TEST_ENABLED: "true"
+      INFLUX_DB_INSTANCE_URL: "http://localhost:8181/"
+      INFLUX_DB_TOKEN: "${{ secrets.INFLUX_TOKEN }}"
+      INFLUX_DB_PRODUCT_TYPE: "core"
+```

--- a/.claude/skills/testing/references/test-architecture.md
+++ b/.claude/skills/testing/references/test-architecture.md
@@ -124,40 +124,41 @@ To add a new test file (e.g., `tests/write.test.ts`):
 For integration tests that need InfluxDB, use the same
 `describe.skipIf(!process.env.INFLUX_TEST_ENABLED)` gate pattern.
 
-## CI Usage
+## Local Docker Infrastructure
 
-### Gating dependency updates (Dependabot, Renovate)
+`docker-compose.test.yml` starts InfluxDB 3 Core with:
+- `--object-store memory` — ephemeral, no volumes
+- Docker secrets to inject `tests/fixtures/admin-token.json` as
+  `--admin-token-file=/run/secrets/admin-token`
+- Healthcheck on `/ping` with `start_period: 10s`
 
-Add to the CI workflow:
+The static token `apiv3_test` in the fixture file is only for ephemeral
+test containers. The `env.test.example` file is pre-filled to match.
 
-```yaml
-- run: npm ci
-- run: npm run build
-- run: npm test
-```
+## CI Workflow
 
-The protocol tests verify:
-1. TypeScript compiles with updated deps (build step)
-2. Server process starts without runtime errors (initialize handshake)
-3. MCP SDK client/server are compatible (protocol handshake succeeds)
-4. All tools, resources, and prompts register correctly (count + name checks)
+The CI workflow at `.github/workflows/ci.yml` has two jobs:
 
-This catches the majority of breaking changes from dependency updates.
+### `test-protocol` (always runs, no InfluxDB)
 
-### Optional live integration in CI
+Runs `npm ci`, `npm run build`, `npm test`. Gates every PR and push to main.
+The protocol tests catch dependency breakage within seconds.
 
-```yaml
-services:
-  influxdb:
-    image: influxdb3-core:latest
-    ports: ["8181:8181"]
-steps:
-  - run: npm ci && npm run build
-  - run: npm test
-  - run: npm run test:integration
-    env:
-      INFLUX_TEST_ENABLED: "true"
-      INFLUX_DB_INSTANCE_URL: "http://localhost:8181/"
-      INFLUX_DB_TOKEN: "${{ secrets.INFLUX_TOKEN }}"
-      INFLUX_DB_PRODUCT_TYPE: "core"
-```
+### `test-integration-core` (InfluxDB 3 Core)
+
+Uses `docker run` (not `services:`) because Core requires
+`--admin-token-file` for token bootstrapping, and the `services:` block
+cannot pass container CMD arguments.
+
+The job:
+1. Checks out the repo (which includes `tests/fixtures/admin-token.json`)
+2. Bind-mounts the token file into the container at `/run/secrets/admin-token`
+3. Polls `/ping` until Core is ready (up to 30 seconds)
+4. Runs `npm run test:integration` with the static test token
+5. Stops the container in an `if: always()` cleanup step
+
+### Future: Enterprise
+
+A third job for Enterprise will be gated on
+`github.repository_owner == 'influxdata'` and require the Enterprise Docker
+image plus a license key stored in `secrets.INFLUXDB_ENTERPRISE_LICENSE`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,34 @@ on:
     branches: [main]
 
 jobs:
+  check-versions:
+    name: Version consistency check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify package.json, config.ts, and CHANGELOG.md versions match
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          CONFIG_VERSION=$(node -p "require('fs').readFileSync('src/config.ts','utf8').match(/version: \"([^\"]+)\"/)[1]")
+          CHANGELOG_VERSION=$(node -p "require('fs').readFileSync('CHANGELOG.md','utf8').match(/^## \\[([^\\]]+)\\]/m)[1]")
+
+          echo "package.json:  $PKG_VERSION"
+          echo "config.ts:     $CONFIG_VERSION"
+          echo "CHANGELOG.md:  $CHANGELOG_VERSION"
+
+          if [ "$PKG_VERSION" != "$CONFIG_VERSION" ]; then
+            echo "::error::package.json ($PKG_VERSION) and config.ts ($CONFIG_VERSION) versions differ"
+            exit 1
+          fi
+          if [ "$PKG_VERSION" != "$CHANGELOG_VERSION" ]; then
+            echo "::error::package.json ($PKG_VERSION) and CHANGELOG.md ($CHANGELOG_VERSION) versions differ"
+            exit 1
+          fi
+          echo "All versions match: $PKG_VERSION"
+
   test-protocol:
     name: Protocol tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-protocol:
+    name: Protocol tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  test-integration-core:
+    name: Integration tests (InfluxDB 3 Core)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Start InfluxDB 3 Core
+        run: |
+          docker run -d --name influxdb3-core \
+            -p 8181:8181 \
+            -v "${{ github.workspace }}/tests/fixtures/admin-token.json:/run/secrets/admin-token:ro" \
+            influxdb:3-core \
+            serve --node-id=ci-test --object-store=memory --admin-token-file=/run/secrets/admin-token
+
+      - name: Wait for InfluxDB to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf -H "Authorization: Bearer apiv3_test" http://localhost:8181/ping > /dev/null 2>&1; then
+              echo "InfluxDB ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "InfluxDB failed to start"
+          docker logs influxdb3-core
+          exit 1
+
+      - name: Integration tests
+        run: npm run test:integration
+        env:
+          INFLUX_TEST_ENABLED: "true"
+          INFLUX_DB_INSTANCE_URL: "http://localhost:8181/"
+          INFLUX_DB_TOKEN: "apiv3_test"
+          INFLUX_DB_PRODUCT_TYPE: "core"
+
+      - name: Stop InfluxDB
+        if: always()
+        run: docker stop influxdb3-core && docker rm influxdb3-core
+
+  # Future: test-integration-enterprise
+  # Requires Enterprise Docker image and license key.
+  # Gate with: if: github.repository_owner == 'influxdata'
+  # Pass license via: secrets.INFLUXDB_ENTERPRISE_LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the official InfluxDB MCP Server will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-03-24
+
+### Added
+
+- **E2E test suite**: Protocol compliance tests (vitest) that verify server startup, MCP handshake, tool/resource/prompt registration, and error handling — no InfluxDB required
+- **Integration tests**: Live InfluxDB tests for `health_check`, `list_databases`, and `execute_query`, gated behind `INFLUX_TEST_ENABLED`
+- **CI workflow**: GitHub Actions with protocol tests on every PR and integration tests against InfluxDB 3 Core via Docker
+- **Docker test infrastructure**: `docker-compose.test.yml` for local Core testing with preconfigured admin token
+- **CLAUDE.md**: Architecture overview and codebase conventions for Claude Code
+- **Claude Code skills**: Build/run workflow for Core/Enterprise and testing workflow
+
+### Fixed
+
+- Server-level error catch now sets `isError: true`, consistent with handler-level error responses
+
+### Changed
+
+- Minimum Node.js version raised to v20.11 (Node 18 is EOL; vitest 4.x and `import.meta.dirname` require v20.11+)
+- `@modelcontextprotocol/sdk` updated from `^1.12.1` to `^1.27.1`
+
 ## [1.2.0] - 2025-11-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+An MCP (Model Context Protocol) server for InfluxDB 3. It exposes tools, resources, and prompts that let MCP clients (Claude Desktop, etc.) query, write, and manage InfluxDB instances over stdio. Supports five InfluxDB product types: `core`, `enterprise`, `cloud-dedicated`, `cloud-serverless`, `clustered`.
+
+## Commands
+
+```bash
+npm run build      # compile TypeScript → build/
+npm run lint       # eslint
+npm run format     # prettier
+npm test           # protocol compliance tests (vitest, no InfluxDB needed)
+```
+
+Build before testing — tests spawn the compiled `build/index.js`.
+For full testing workflow, see `.claude/skills/testing/`.
+
+For full build/run/Docker/environment setup for Core and Enterprise, see
+the skill at `.claude/skills/build-run-core-enterprise/`.
+
+### Environment
+
+Configured via `.env` (copy from `env.*.example`). The `INFLUX_DB_PRODUCT_TYPE`
+env var (`core`, `enterprise`, `cloud-dedicated`, `cloud-serverless`, `clustered`)
+determines available tools and API behavior. See `src/config.ts` for validation
+rules per product type.
+
+## Architecture
+
+### Layers
+
+```
+src/index.ts                    ← Entry point: stdio transport
+src/server/index.ts             ← Server factory: config → services → MCP handlers
+src/config.ts                   ← Env loading + validation (per product type)
+src/services/                   ← Domain logic
+  influxdb-master.service.ts    ← Facade: orchestrates all services below
+  base-connection.service.ts    ← Client init, ping, health, data/management host routing
+  http-client.service.ts        ← Axios wrapper with product-type-aware auth headers
+  query.service.ts              ← SQL query execution, schema discovery
+  write.service.ts              ← Line protocol writes
+  database-management.service.ts
+  token-management.service.ts   ← Core/Enterprise token CRUD
+  cloud-token-management.service.ts ← Cloud Dedicated/Clustered token CRUD
+  serverless-schema-management.service.ts
+  help.service.ts
+  context-file.service.ts       ← Loads user context from context/ directory
+src/tools/                      ← MCP tool definitions
+  index.ts                      ← Aggregates all tool categories
+  categories/*.tools.ts         ← Each file defines tools with Zod schema + handler
+src/resources/index.ts          ← MCP resources (config, status, databases, context)
+src/prompts/index.ts            ← MCP prompt templates
+src/helpers/enums/              ← InfluxProductType enum
+```
+
+### Key Patterns
+
+- **Product-type branching**: Many operations behave differently per product type. `BaseConnectionService` separates data-plane vs management-plane hosts. `validateOperationSupport()` gates tools to supported product types. Auth headers differ (`Token` for cloud-serverless, `Bearer` for others).
+- **Dual-plane architecture for cloud-dedicated/clustered**: Data operations use the cluster host (`{cluster_id}.a.influxdb.io`), management operations use `console.influxdata.com`. The `clustered` type uses dummy IDs for compatibility with cloud-dedicated handlers.
+- **Tool structure**: Each tool in `src/tools/categories/` exports a `createXTools(influxService)` function returning `McpTool[]`. Each tool has both a JSON Schema `inputSchema` (for MCP protocol) and a `zodSchema` (for runtime validation in `server/index.ts`). Keep these in sync.
+- **All logging goes to stderr** (`console.error`/`console.warn`), since stdout is the MCP stdio transport.
+
+## Conventions
+
+- ESM modules (`"type": "module"` in package.json), `.js` extensions in all imports (even for `.ts` files — required by Node16 module resolution)
+- TypeScript strict mode, target ES2022
+- Unused vars prefixed with `_` (eslint configured to allow this)
+- `@typescript-eslint/no-explicit-any` is disabled — the codebase uses `any` freely
+- Tests use vitest; `tests/` is compiled by vitest's Vite pipeline, not `tsc` (separate from `tsconfig.json`)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Model Context Protocol (MCP) server for InfluxDB 3 integration. Provides tools, 
 ## Prerequisites
 
 - **InfluxDB 3 Instance**: URL and token (Core/Enterprise/Cloud Serverless) or Cluster ID and tokens (Cloud Dedicated/Clustered)
-- **Node.js**: v18 or newer (for npm/npx usage)
+- **Node.js**: v20.11 or newer (for npm/npx usage)
 - **npm**: v9 or newer (for npm/npx usage)
 - **Docker**: (for Docker-based setup)
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,23 @@
+services:
+  influxdb3-core:
+    image: influxdb:3-core
+    ports:
+      - "8181:8181"
+    command:
+      - influxdb3
+      - serve
+      - --node-id=local-test
+      - --object-store=memory
+      - --admin-token-file=/run/secrets/admin-token
+    secrets:
+      - admin-token
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "Authorization: Bearer apiv3_test", "http://localhost:8181/ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+secrets:
+  admin-token:
+    file: tests/fixtures/admin-token.json

--- a/env.test.example
+++ b/env.test.example
@@ -1,0 +1,12 @@
+# InfluxDB MCP Server — integration test configuration
+# Source this file before running integration tests:
+#   source env.test.example && npm run test:integration
+#
+# Pre-filled for docker-compose.test.yml with tests/fixtures/admin-token.json.
+# The token value must match the "token" field in tests/fixtures/admin-token.json.
+# .env.test is gitignored (by the .env* rule) — copy to .env.test to customize.
+
+export INFLUX_TEST_ENABLED=true
+export INFLUX_DB_INSTANCE_URL=http://localhost:8181/
+export INFLUX_DB_TOKEN=apiv3_test
+export INFLUX_DB_PRODUCT_TYPE=core

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@influxdata/influxdb3-client": "^1.1.0",
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "axios": "^1.12.0",
         "dotenv": "^16.5.0"
       },
@@ -25,7 +25,42 @@
         "eslint": "^9.28.0",
         "prettier": "^3.5.3",
         "typescript": "^5.0.0",
+        "vitest": "^4.1.1",
         "zod": "^3.25.63"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -213,6 +248,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -293,6 +340,13 @@
         "grpc-web": "^1.5.0"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
@@ -304,25 +358,82 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.3.tgz",
-      "integrity": "sha512-DyVYSOafBvk3/j1Oka4z5BWT8o4AFmoNyZY9pALOm7Lh3GZglR71Co4r4dEUoqDWdDazIZQHBe7J2Nwkg6gHgQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -358,6 +469,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@protobuf-ts/grpc-transport": {
@@ -462,6 +583,293 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -469,6 +877,28 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/command-line-args": {
@@ -481,6 +911,13 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -751,6 +1188,119 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -791,6 +1341,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -802,6 +1353,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -878,6 +1468,16 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -903,9 +1503,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
-      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -914,7 +1514,7 @@
         "http-errors": "^2.0.0",
         "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
+        "qs": "^6.14.1",
         "raw-body": "^3.0.1",
         "type-is": "^2.0.1"
       },
@@ -995,6 +1595,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1118,15 +1728,16 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -1137,6 +1748,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1225,6 +1843,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
@@ -1289,6 +1917,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1490,6 +2125,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1528,6 +2173,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1574,10 +2229,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1585,7 +2243,7 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1626,6 +2284,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -1634,6 +2293,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -1670,9 +2345,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1683,7 +2358,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-replace": {
@@ -1820,6 +2499,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1975,6 +2669,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1996,9 +2699,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2053,6 +2756,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2116,6 +2828,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2148,7 +2869,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2179,6 +2907,279 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -2215,6 +3216,16 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2278,15 +3289,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -2307,6 +3322,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2344,6 +3378,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -2458,13 +3503,28 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2485,6 +3545,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -2560,15 +3649,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2633,6 +3723,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2651,6 +3750,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.11"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
       }
     },
     "node_modules/router": {
@@ -2692,26 +3825,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2731,31 +3844,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -2765,6 +3882,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -2866,6 +3987,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2874,6 +4019,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2937,6 +4089,81 @@
       },
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3047,6 +4274,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -3059,6 +4287,192 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.11",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {
@@ -3074,6 +4488,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -3177,12 +4608,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "influxdb-mcp-server",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "Official InfluxDB MCP server for Model Context Protocol integration",
   "license": "(Apache-2.0 OR MIT)",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "lint": "eslint . --ext .ts,.js",
     "format": "prettier --write .",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "npm run build && node build/index.js --help || echo 'Build test completed'",
+    "test": "vitest run",
+    "test:integration": "INFLUX_TEST_ENABLED=true vitest run tests/integration.test.ts",
+    "test:watch": "vitest",
     "MCP inspector": "npx @modelcontextprotocol/inspector node build/index.js",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",
@@ -49,7 +51,7 @@
   ],
   "dependencies": {
     "@influxdata/influxdb3-client": "^1.1.0",
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "axios": "^1.12.0",
     "dotenv": "^16.5.0"
   },
@@ -61,6 +63,7 @@
     "eslint": "^9.28.0",
     "prettier": "^3.5.3",
     "typescript": "^5.0.0",
+    "vitest": "^4.1.1",
     "zod": "^3.25.63"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint . --ext .ts,.js",
     "format": "prettier --write .",
     "prepublishOnly": "npm run clean && npm run build",
+    "pretest": "npm run build",
     "test": "vitest run",
     "test:integration": "INFLUX_TEST_ENABLED=true vitest run tests/integration.test.ts",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "(Apache-2.0 OR MIT)",
   "private": false,
   "type": "module",
+  "engines": {
+    "node": ">=20.11.0"
+  },
   "main": "./build/index.js",
   "bin": {
     "influxdb-mcp-server": "./build/index.js"
@@ -21,6 +24,8 @@
     "test": "vitest run",
     "test:integration": "INFLUX_TEST_ENABLED=true vitest run tests/integration.test.ts",
     "test:watch": "vitest",
+    "test:infra:up": "docker compose -f docker-compose.test.yml up -d --wait",
+    "test:infra:down": "docker compose -f docker-compose.test.yml down",
     "MCP inspector": "npx @modelcontextprotocol/inspector node build/index.js",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export function loadConfig(): McpServerConfig {
     },
     server: {
       name: "influxdb-mcp-server",
-      version: "1.2.0",
+      version: "1.3.0",
     },
   };
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -78,6 +78,7 @@ export function createServer(): Server {
             text: `Error: ${error instanceof Error ? error.message : String(error)}`,
           },
         ],
+        isError: true,
       };
     }
   });

--- a/tests/fixtures/admin-token.json
+++ b/tests/fixtures/admin-token.json
@@ -1,0 +1,5 @@
+{
+  "token": "apiv3_test",
+  "name": "admin",
+  "description": "Static token for ephemeral test containers only — not a real credential"
+}

--- a/tests/helpers/mcp-client.ts
+++ b/tests/helpers/mcp-client.ts
@@ -21,7 +21,7 @@ export async function createTestClient(
   const transport = new StdioClientTransport({
     command: "node",
     args: [SERVER_PATH],
-    env: { ...(process.env as NodeJS.ProcessEnv), ...BASE_ENV, ...env } as NodeJS.ProcessEnv,
+    env: { ...BASE_ENV, ...env },
     stderr: "pipe",
   });
 

--- a/tests/helpers/mcp-client.ts
+++ b/tests/helpers/mcp-client.ts
@@ -21,7 +21,7 @@ export async function createTestClient(
   const transport = new StdioClientTransport({
     command: "node",
     args: [SERVER_PATH],
-    env: { ...BASE_ENV, ...env },
+    env: { ...(process.env as NodeJS.ProcessEnv), ...BASE_ENV, ...env } as NodeJS.ProcessEnv,
     stderr: "pipe",
   });
 

--- a/tests/helpers/mcp-client.ts
+++ b/tests/helpers/mcp-client.ts
@@ -1,0 +1,43 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { resolve } from "node:path";
+
+const SERVER_PATH = resolve(import.meta.dirname, "../../build/index.js");
+
+const BASE_ENV: Record<string, string> = {
+  INFLUX_DB_INSTANCE_URL: "http://localhost:19999/",
+  INFLUX_DB_TOKEN: "test-token-not-used",
+  INFLUX_DB_PRODUCT_TYPE: "core",
+};
+
+export interface TestClient {
+  client: Client;
+  close: () => Promise<void>;
+}
+
+export async function createTestClient(
+  env?: Record<string, string>,
+): Promise<TestClient> {
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [SERVER_PATH],
+    env: { ...BASE_ENV, ...env },
+    stderr: "pipe",
+  });
+
+  const client = new Client(
+    { name: "test-client", version: "1.0.0" },
+  );
+
+  await client.connect(transport);
+
+  const close = async () => {
+    try {
+      await client.close();
+    } catch {
+      // Server process may already be gone
+    }
+  };
+
+  return { client, close };
+}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createTestClient, TestClient } from "./helpers/mcp-client.js";
 
-const RUN = !!process.env.INFLUX_TEST_ENABLED;
+const RUN =
+  process.env.INFLUX_TEST_ENABLED === "true" ||
+  process.env.INFLUX_TEST_ENABLED === "1";
 
 describe.skipIf(!RUN)("live InfluxDB integration", () => {
   let testClient: TestClient;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestClient, TestClient } from "./helpers/mcp-client.js";
+
+const RUN = !!process.env.INFLUX_TEST_ENABLED;
+
+describe.skipIf(!RUN)("live InfluxDB integration", () => {
+  let testClient: TestClient;
+
+  beforeAll(async () => {
+    testClient = await createTestClient({
+      INFLUX_DB_INSTANCE_URL: process.env.INFLUX_DB_INSTANCE_URL ?? "",
+      INFLUX_DB_TOKEN: process.env.INFLUX_DB_TOKEN ?? "",
+      INFLUX_DB_PRODUCT_TYPE: process.env.INFLUX_DB_PRODUCT_TYPE ?? "core",
+    });
+  });
+
+  afterAll(async () => {
+    await testClient?.close();
+  });
+
+  it("health_check reports healthy", async () => {
+    const result = await testClient.client.callTool({
+      name: "health_check",
+      arguments: {},
+    });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      ?.text;
+    expect(text).toContain("HEALTHY");
+  });
+
+  it("list_databases returns a response", async () => {
+    const result = await testClient.client.callTool({
+      name: "list_databases",
+      arguments: {},
+    });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      ?.text;
+    expect(text).toBeDefined();
+    expect(text).toContain("Found");
+  });
+
+  it("execute_query runs a simple query", async () => {
+    // First get a database name from list_databases
+    const dbResult = await testClient.client.callTool({
+      name: "list_databases",
+      arguments: {},
+    });
+    const dbText = (
+      dbResult.content as Array<{ type: string; text: string }>
+    )[0]?.text;
+
+    // If no databases exist, skip gracefully
+    if (dbText?.includes("Found 0 databases")) {
+      return;
+    }
+
+    // Extract first database name from the JSON in the response
+    const dbMatch = dbText?.match(/"name":\s*"([^"]+)"/);
+    if (!dbMatch) {
+      return;
+    }
+
+    const result = await testClient.client.callTool({
+      name: "execute_query",
+      arguments: {
+        database: dbMatch[1],
+        query: "SELECT 1 AS test",
+      },
+    });
+    expect(result.content).toBeDefined();
+    expect((result as { isError?: boolean }).isError).not.toBe(true);
+  });
+});

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestClient, TestClient } from "./helpers/mcp-client.js";
+
+// Update this when tools are added or removed.
+// Verified against: src/tools/index.ts createTools() aggregation.
+// help(2) + write(1) + database(4) + query(3) + token(6) + cloud-token(5) + health(1) = 22
+const EXPECTED_TOOL_COUNT = 22;
+
+const EXPECTED_RESOURCE_URIS = [
+  "influx://config",
+  "influx://status",
+  "influx://databases",
+  "influx://context",
+];
+
+const EXPECTED_PROMPT_NAMES = [
+  "list-databases",
+  "check-health",
+  "load-context",
+];
+
+describe("MCP protocol compliance", () => {
+  let testClient: TestClient;
+
+  beforeAll(async () => {
+    testClient = await createTestClient();
+  });
+
+  afterAll(async () => {
+    await testClient?.close();
+  });
+
+  it("completes initialize handshake and reports capabilities", () => {
+    const capabilities = testClient.client.getServerCapabilities();
+    expect(capabilities).toBeDefined();
+    expect(capabilities).toHaveProperty("tools");
+    expect(capabilities).toHaveProperty("resources");
+    expect(capabilities).toHaveProperty("prompts");
+  });
+
+  it("returns server version info", () => {
+    const serverInfo = testClient.client.getServerVersion();
+    expect(serverInfo).toBeDefined();
+    expect(serverInfo?.name).toBe("influxdb-mcp-server");
+    expect(serverInfo?.version).toBeDefined();
+  });
+
+  describe("tools/list", () => {
+    it("returns the expected number of tools", async () => {
+      const result = await testClient.client.listTools();
+      expect(result.tools).toHaveLength(EXPECTED_TOOL_COUNT);
+    });
+
+    it("each tool has name, description, and inputSchema", async () => {
+      const result = await testClient.client.listTools();
+      for (const tool of result.tools) {
+        expect(tool.name).toBeTruthy();
+        expect(tool.description).toBeTruthy();
+        expect(tool.inputSchema).toBeDefined();
+        expect(tool.inputSchema.type).toBe("object");
+      }
+    });
+
+    it("includes core tools by name", async () => {
+      const result = await testClient.client.listTools();
+      const names = result.tools.map((t) => t.name);
+      expect(names).toContain("health_check");
+      expect(names).toContain("execute_query");
+      expect(names).toContain("write_line_protocol");
+      expect(names).toContain("list_databases");
+      expect(names).toContain("create_admin_token");
+    });
+  });
+
+  describe("resources/list", () => {
+    it("returns all expected resources", async () => {
+      const result = await testClient.client.listResources();
+      const uris = result.resources.map((r) => r.uri);
+      expect(uris).toEqual(expect.arrayContaining(EXPECTED_RESOURCE_URIS));
+      expect(result.resources).toHaveLength(EXPECTED_RESOURCE_URIS.length);
+    });
+
+    it("each resource has name, uri, and description", async () => {
+      const result = await testClient.client.listResources();
+      for (const resource of result.resources) {
+        expect(resource.name).toBeTruthy();
+        expect(resource.uri).toBeTruthy();
+        expect(resource.description).toBeTruthy();
+      }
+    });
+  });
+
+  describe("prompts/list", () => {
+    it("returns all expected prompts", async () => {
+      const result = await testClient.client.listPrompts();
+      const names = result.prompts.map((p) => p.name);
+      expect(names).toEqual(expect.arrayContaining(EXPECTED_PROMPT_NAMES));
+      expect(result.prompts).toHaveLength(EXPECTED_PROMPT_NAMES.length);
+    });
+  });
+
+  describe("ping", () => {
+    it("responds to ping", async () => {
+      const result = await testClient.client.ping();
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws McpError for unknown tool", async () => {
+      await expect(
+        testClient.client.callTool({
+          name: "nonexistent_tool",
+          arguments: {},
+        }),
+      ).rejects.toThrow("Unknown tool: nonexistent_tool");
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,9 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const buildPath = resolve(import.meta.dirname, "../build/index.js");
+if (!existsSync(buildPath)) {
+  throw new Error(
+    `build/index.js not found at ${buildPath}. Run \`npm run build\` before running tests.`,
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["tests/setup.ts"],
+    testTimeout: 15000,
+    hookTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary

- Add a two-layer test suite using vitest that exercises the real MCP server
  by spawning it as a child process via the MCP SDK client
- Protocol compliance tests (10 tests, no InfluxDB needed) verify server
  startup, tool/resource/prompt registration, ping, and error handling
- Integration tests (3 tests, gated behind `INFLUX_TEST_ENABLED`) verify
  `health_check`, `list_databases`, and `execute_query` against a live instance
- Add `CLAUDE.md` with architecture overview and codebase conventions
- Add Claude Code skills for build/run and testing workflows

## Test plan

- [x] `npm run build && npm test` passes (10 protocol tests pass, 3 integration tests skip)
- [x] Run integration tests against a live InfluxDB 3 Core instance
- [x] Follow-up: add `docker-compose.test.yml` for local Core testing and CI workflow