### PR TITLE
fix: add data.message check to query error handler, add error-path tests

### DIFF
--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -179,6 +179,7 @@ export class QueryService {
   private handleQueryError(error: any): never {
     const errorMessage =
       error.response?.data?.error ||
+      error.response?.data?.message ||
       (typeof error.response?.data === "string" ? error.response.data : null) ||
       error.response?.statusText ||
       error.message;

--- a/src/services/query.service.ts
+++ b/src/services/query.service.ts
@@ -178,8 +178,8 @@ export class QueryService {
    */
   private handleQueryError(error: any): never {
     const errorMessage =
-      error.response?.data?.error ||
       error.response?.data?.message ||
+      error.response?.data?.error ||
       (typeof error.response?.data === "string" ? error.response.data : null) ||
       error.response?.statusText ||
       error.message;

--- a/tests/fixtures/error-responses.ts
+++ b/tests/fixtures/error-responses.ts
@@ -1,0 +1,108 @@
+/**
+ * Recorded InfluxDB error response fixtures.
+ *
+ * Axios errors (Core paths) have: error.response.status, error.response.statusText, error.response.data
+ * SDK HttpError (Serverless paths) has: error.statusCode, error.statusMessage, error.body, error.json, error.message
+ */
+
+export interface AxiosErrorShape {
+  response: {
+    status: number;
+    statusText: string;
+    data: unknown;
+  };
+  message: string;
+}
+
+export interface SdkErrorShape {
+  statusCode: number;
+  statusMessage: string | undefined;
+  body: string | undefined;
+  json: unknown;
+  message: string;
+}
+
+// ── Core / axios-based fixtures ────────────────────────────────────────────
+
+export const CORE_404_NONEXISTENT_DB: AxiosErrorShape = {
+  response: {
+    status: 404,
+    statusText: "Not Found",
+    data: { error: "query error: database not found: nonexistent" },
+  },
+  message: "Request failed with status code 404",
+};
+
+export const CORE_400_BAD_WRITE: AxiosErrorShape = {
+  response: {
+    status: 400,
+    statusText: "Bad Request",
+    data: {
+      error: "partial write of line protocol occurred",
+      data: [
+        {
+          error_message: "No fields were provided",
+          line_number: 1,
+          original_line: "invalid line protoco",
+        },
+      ],
+    },
+  },
+  message: "Request failed with status code 400",
+};
+
+export const CORE_500_INVALID_SQL: AxiosErrorShape = {
+  response: {
+    status: 500,
+    statusText: "Internal Server Error",
+    data: 'query error: error while planning query: SQL error: ParserError("Expected: an SQL statement, found: THIS at Line: 1, Column: 1")',
+  },
+  message: "Request failed with status code 500",
+};
+
+// ── Cloud Serverless / axios-shaped with {code, message} format ────────────
+
+export const SERVERLESS_AXIOS_400_INVALID_QUERY: AxiosErrorShape = {
+  response: {
+    status: 400,
+    statusText: "Bad Request",
+    data: { code: "invalid", message: "invalid: unknown query type: sql" },
+  },
+  message: "Request failed with status code 400",
+};
+
+export const SERVERLESS_AXIOS_404_NONEXISTENT_BUCKET: AxiosErrorShape = {
+  response: {
+    status: 404,
+    statusText: "Not Found",
+    data: {
+      code: "not found",
+      message:
+        'failed to initialize execute state: could not find bucket "nonexistent"',
+    },
+  },
+  message: "Request failed with status code 404",
+};
+
+// ── Cloud Serverless / SDK HttpError fixtures ──────────────────────────────
+
+export const SERVERLESS_SDK_400_INVALID_QUERY: SdkErrorShape = {
+  statusCode: 400,
+  statusMessage: "Bad Request",
+  body: '{"code":"invalid","message":"invalid: unknown query type: sql"}',
+  json: { code: "invalid", message: "invalid: unknown query type: sql" },
+  message: "invalid: unknown query type: sql",
+};
+
+export const SERVERLESS_SDK_404_NONEXISTENT_BUCKET: SdkErrorShape = {
+  statusCode: 404,
+  statusMessage: "Not Found",
+  body: '{"code":"not found","message":"failed to initialize execute state: could not find bucket \\"nonexistent\\""}',
+  json: {
+    code: "not found",
+    message:
+      'failed to initialize execute state: could not find bucket "nonexistent"',
+  },
+  message:
+    'failed to initialize execute state: could not find bucket "nonexistent"',
+};

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -9,11 +9,11 @@ describe.skipIf(!RUN)("live InfluxDB integration", () => {
   let testClient: TestClient;
 
   beforeAll(async () => {
-    testClient = await createTestClient({
-      INFLUX_DB_INSTANCE_URL: process.env.INFLUX_DB_INSTANCE_URL ?? "",
-      INFLUX_DB_TOKEN: process.env.INFLUX_DB_TOKEN ?? "",
-      INFLUX_DB_PRODUCT_TYPE: process.env.INFLUX_DB_PRODUCT_TYPE ?? "core",
-    });
+    const env: Record<string, string> = {};
+    if (process.env.INFLUX_DB_INSTANCE_URL) env.INFLUX_DB_INSTANCE_URL = process.env.INFLUX_DB_INSTANCE_URL;
+    if (process.env.INFLUX_DB_TOKEN) env.INFLUX_DB_TOKEN = process.env.INFLUX_DB_TOKEN;
+    if (process.env.INFLUX_DB_PRODUCT_TYPE) env.INFLUX_DB_PRODUCT_TYPE = process.env.INFLUX_DB_PRODUCT_TYPE;
+    testClient = await createTestClient(env);
   });
 
   afterAll(async () => {

--- a/tests/query-error-core.test.ts
+++ b/tests/query-error-core.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { QueryService } from "../src/services/query.service.js";
+import { BaseConnectionService } from "../src/services/base-connection.service.js";
+import {
+  AxiosErrorShape,
+  CORE_404_NONEXISTENT_DB,
+  CORE_400_BAD_WRITE,
+  CORE_500_INVALID_SQL,
+} from "./fixtures/error-responses.js";
+
+function stubBaseService(): BaseConnectionService {
+  return {
+    validateDataCapabilities: vi.fn(),
+    getConnectionInfo: vi.fn().mockReturnValue({ type: "core" }),
+    getInfluxHttpClient: vi.fn(),
+    getClient: vi.fn().mockReturnValue(null),
+  } as unknown as BaseConnectionService;
+}
+
+function httpClientThrowing(error: AxiosErrorShape) {
+  return { post: vi.fn().mockRejectedValue(error) };
+}
+
+describe("handleQueryError – Core (axios) error path", () => {
+  it("404: surfaces InfluxDB error from JSON {error:...} response", async () => {
+    const base = stubBaseService();
+    vi.mocked(base.getInfluxHttpClient).mockReturnValue(
+      httpClientThrowing(CORE_404_NONEXISTENT_DB) as any,
+    );
+    const svc = new QueryService(base);
+
+    await expect(
+      svc.executeQuery("SELECT 1", "nonexistent"),
+    ).rejects.toThrow(
+      /^Database not found: query error: database not found: nonexistent$/,
+    );
+  });
+
+  it("400: surfaces InfluxDB error from JSON {error:...} response", async () => {
+    const base = stubBaseService();
+    vi.mocked(base.getInfluxHttpClient).mockReturnValue(
+      httpClientThrowing(CORE_400_BAD_WRITE) as any,
+    );
+    const svc = new QueryService(base);
+
+    await expect(
+      svc.executeQuery("SELECT 1", "mydb"),
+    ).rejects.toThrow(
+      /^Bad request: partial write of line protocol occurred$/,
+    );
+  });
+
+  it("500: surfaces plain-text error body", async () => {
+    const base = stubBaseService();
+    vi.mocked(base.getInfluxHttpClient).mockReturnValue(
+      httpClientThrowing(CORE_500_INVALID_SQL) as any,
+    );
+    const svc = new QueryService(base);
+
+    await expect(
+      svc.executeQuery("THIS IS NOT SQL", "mydb"),
+    ).rejects.toThrow(/^Query failed:.*ParserError.*Expected: an SQL statement/);
+  });
+});

--- a/tests/query-error-integration.test.ts
+++ b/tests/query-error-integration.test.ts
@@ -11,11 +11,11 @@ describe.skipIf(!RUN)(
     let testClient: TestClient;
 
     beforeAll(async () => {
-      testClient = await createTestClient({
-        INFLUX_DB_INSTANCE_URL: process.env.INFLUX_DB_INSTANCE_URL ?? "",
-        INFLUX_DB_TOKEN: process.env.INFLUX_DB_TOKEN ?? "",
-        INFLUX_DB_PRODUCT_TYPE: process.env.INFLUX_DB_PRODUCT_TYPE ?? "core",
-      });
+      const env: Record<string, string> = {};
+      if (process.env.INFLUX_DB_INSTANCE_URL) env.INFLUX_DB_INSTANCE_URL = process.env.INFLUX_DB_INSTANCE_URL;
+      if (process.env.INFLUX_DB_TOKEN) env.INFLUX_DB_TOKEN = process.env.INFLUX_DB_TOKEN;
+      if (process.env.INFLUX_DB_PRODUCT_TYPE) env.INFLUX_DB_PRODUCT_TYPE = process.env.INFLUX_DB_PRODUCT_TYPE;
+      testClient = await createTestClient(env);
     });
 
     afterAll(async () => {

--- a/tests/query-error-integration.test.ts
+++ b/tests/query-error-integration.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestClient, TestClient } from "./helpers/mcp-client.js";
+
+const RUN =
+  process.env.INFLUX_TEST_ENABLED === "true" ||
+  process.env.INFLUX_TEST_ENABLED === "1";
+
+describe.skipIf(!RUN)(
+  "error path integration tests (live Core)",
+  () => {
+    let testClient: TestClient;
+
+    beforeAll(async () => {
+      testClient = await createTestClient({
+        INFLUX_DB_INSTANCE_URL: process.env.INFLUX_DB_INSTANCE_URL ?? "",
+        INFLUX_DB_TOKEN: process.env.INFLUX_DB_TOKEN ?? "",
+        INFLUX_DB_PRODUCT_TYPE: process.env.INFLUX_DB_PRODUCT_TYPE ?? "core",
+      });
+    });
+
+    afterAll(async () => {
+      await testClient?.close();
+    });
+
+    it("execute_query on nonexistent database surfaces real error", async () => {
+      const result = await testClient.client.callTool({
+        name: "execute_query",
+        arguments: {
+          database: "nonexistent_db_xyz",
+          query: "SELECT 1",
+        },
+      });
+
+      const text = (
+        result.content as Array<{ type: string; text: string }>
+      )[0]?.text;
+
+      expect(text).toMatch(/database not found/i);
+      expect(text).not.toMatch("Internal Server Error");
+    });
+
+    it("execute_query with invalid SQL surfaces parser error", async () => {
+      const dbResult = await testClient.client.callTool({
+        name: "list_databases",
+        arguments: {},
+      });
+      const dbText = (
+        dbResult.content as Array<{ type: string; text: string }>
+      )[0]?.text;
+
+      if (dbText?.includes("Found 0 databases")) {
+        return;
+      }
+
+      const dbMatch = dbText?.match(/"name":\s*"([^"]+)"/);
+      if (!dbMatch) {
+        return;
+      }
+
+      const result = await testClient.client.callTool({
+        name: "execute_query",
+        arguments: {
+          database: dbMatch[1],
+          query: "THIS IS NOT SQL",
+        },
+      });
+
+      const text = (
+        result.content as Array<{ type: string; text: string }>
+      )[0]?.text;
+
+      expect(text).toMatch(/ParserError|SQL error/i);
+    });
+  },
+);

--- a/tests/query-error-serverless.test.ts
+++ b/tests/query-error-serverless.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import { QueryService } from "../src/services/query.service.js";
+import { BaseConnectionService } from "../src/services/base-connection.service.js";
+import { InfluxProductType } from "../src/helpers/enums/influx-product-types.enum.js";
+import {
+  AxiosErrorShape,
+  SdkErrorShape,
+  SERVERLESS_SDK_400_INVALID_QUERY,
+  SERVERLESS_SDK_404_NONEXISTENT_BUCKET,
+  SERVERLESS_AXIOS_400_INVALID_QUERY,
+  SERVERLESS_AXIOS_404_NONEXISTENT_BUCKET,
+} from "./fixtures/error-responses.js";
+
+function stubBaseService(type: InfluxProductType): BaseConnectionService {
+  return {
+    validateDataCapabilities: vi.fn(),
+    getConnectionInfo: vi.fn().mockReturnValue({ type }),
+    getInfluxHttpClient: vi.fn(),
+    getClient: vi.fn().mockReturnValue(null),
+  } as unknown as BaseConnectionService;
+}
+
+function httpClientThrowing(error: AxiosErrorShape) {
+  return { post: vi.fn().mockRejectedValue(error) };
+}
+
+function sdkClientThrowing(error: SdkErrorShape) {
+  const throwingIterable = {
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          return Promise.reject(error);
+        },
+        return() {
+          return Promise.resolve({ value: undefined, done: true as const });
+        },
+      };
+    },
+  };
+  return {
+    queryPoints: vi.fn().mockReturnValue(throwingIterable),
+    write: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+describe("handleQueryError – Cloud Serverless (SDK async iterator)", () => {
+  it("400: surfaces error message from SDK HttpError", async () => {
+    const base = stubBaseService(InfluxProductType.CloudServerless);
+    vi.mocked(base.getClient).mockReturnValue(
+      sdkClientThrowing(SERVERLESS_SDK_400_INVALID_QUERY) as any,
+    );
+    const svc = new QueryService(base);
+
+    await expect(
+      svc.executeQuery("SELECT 1", "mybucket"),
+    ).rejects.toThrow(/unknown query type/);
+  });
+
+  it("404: surfaces error message from SDK HttpError", async () => {
+    const base = stubBaseService(InfluxProductType.CloudServerless);
+    vi.mocked(base.getClient).mockReturnValue(
+      sdkClientThrowing(SERVERLESS_SDK_404_NONEXISTENT_BUCKET) as any,
+    );
+    const svc = new QueryService(base);
+
+    await expect(
+      svc.executeQuery("SELECT 1", "nonexistent"),
+    ).rejects.toThrow(/could not find bucket/);
+  });
+});
+
+describe("handleQueryError – Serverless {code,message} via axios path", () => {
+  // These test the data.message extraction added to handleQueryError.
+  // Before the fix, data.error was undefined (field is "message"),
+  // so errors fell through to statusText ("Bad Request" / "Not Found").
+
+  it("400: surfaces message from {code, message} JSON response", async () => {
+    const base = stubBaseService(InfluxProductType.Core);
+    vi.mocked(base.getInfluxHttpClient).mockReturnValue(
+      httpClientThrowing(SERVERLESS_AXIOS_400_INVALID_QUERY) as any,
+    );
+    const svc = new QueryService(base);
+
+    await expect(
+      svc.executeQuery("SELECT 1", "mydb"),
+    ).rejects.toThrow(/unknown query type/);
+  });
+
+  it("404: surfaces message from {code, message} JSON response", async () => {
+    const base = stubBaseService(InfluxProductType.Core);
+    vi.mocked(base.getInfluxHttpClient).mockReturnValue(
+      httpClientThrowing(SERVERLESS_AXIOS_404_NONEXISTENT_BUCKET) as any,
+    );
+    const svc = new QueryService(base);
+
+    await expect(
+      svc.executeQuery("SELECT 1", "nonexistent"),
+    ).rejects.toThrow(/could not find bucket/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `data.message` to the error extraction chain in `query.service.ts` `handleQueryError`, fixing a gap where Cloud Serverless `{"code":"...","message":"..."}` errors lost their detail to the generic `statusText` fallback
- Add unit tests with recorded error fixtures from live Core and Cloud Serverless instances

## Root cause

`handleQueryError` checked `data.error` but not `data.message`. The other 3 services (database-management, cloud-token-management, serverless-schema-management) already check `data.message` first. This one-line addition makes the query service consistent.

## Error fixtures recorded from live instances

| Source | Status | Format | Key field |
|---|---|---|---|
| Core | 404 | JSON `{error:...}` | `data.error` |
| Core | 400 | JSON `{error:...}` | `data.error` |
| Core | 500 | Plain text string | `typeof data === "string"` |
| Cloud Serverless | 400 | JSON `{code:..., message:...}` | `data.message` (the fixed path) |
| Cloud Serverless | 404 | JSON `{code:..., message:...}` | `data.message` (the fixed path) |

## Test plan

- [x] 17 unit/protocol tests pass, 5 integration tests skip cleanly
- [x] Core axios error path: 3 tests (404 JSON, 400 JSON, 500 plain-text)
- [x] Serverless SDK error path: 2 tests (400, 404 via HttpError)
- [x] Serverless axios error path: 2 tests (400, 404 via data.message — the fixed path)
- [x] Integration error tests: 2 tests (gated, verified against live Core)

## Known remaining gaps (separate PRs)

- `write.service.ts` discards all server error detail for 400/401/403/413/422
- `serverless-schema-management.service.ts` `updateSchema` bypasses `handleSchemaError`