### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Model Context Protocol (MCP) server for InfluxDB 3 integration. Provides tools, 
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/influxdata-influxdb3-mcp-server).
+
 ## Setup & Integration Guide
 
 ### 1. Environment Variables


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/influxdata-influxdb3-mcp-server).