### PR TITLE
feat: Add Enterprise/Core retention policy support to update_database (supersedes #56)

### DIFF
--- a/.claude/skills/build-run-core-enterprise/SKILL.md
+++ b/.claude/skills/build-run-core-enterprise/SKILL.md
@@ -43,11 +43,11 @@ Copy `env.example` as a starting point: `cp env.example .env`
 
 ### Token types (Core/Enterprise)
 
-| Token Type | Purpose | How to obtain |
-|---|---|---|
-| Operator | Full admin, bootstraps the instance | Printed on first `influxdb3 serve` start |
-| Admin | Full admin except managing other admins | Created via `create_admin_token` tool |
-| Resource | Scoped read/write on specific databases | Created via `create_resource_token` tool |
+| Token Type | Purpose                                 | How to obtain                            |
+| ---------- | --------------------------------------- | ---------------------------------------- |
+| Operator   | Full admin, bootstraps the instance     | Printed on first `influxdb3 serve` start |
+| Admin      | Full admin except managing other admins | Created via `create_admin_token` tool    |
+| Resource   | Scoped read/write on specific databases | Created via `create_resource_token` tool |
 
 Use the operator token during initial setup. Create scoped resource tokens for
 applications.
@@ -105,6 +105,7 @@ npm run "MCP inspector"   # quotes required (space in script name)
 ```
 
 This launches the inspector connected to the built server. Use it to:
+
 - Call `health_check` to verify connectivity
 - Call `list_databases` to confirm data access
 - Test `execute_query` with a simple SQL query
@@ -113,25 +114,25 @@ This launches the inspector connected to the built server. Use it to:
 
 All tools available for Core/Enterprise instances:
 
-| Tool | Description |
-|---|---|
-| `health_check` | Verify connection and health status |
-| `list_databases` | List all databases |
-| `create_database` | Create a new database |
-| `update_database` | Update retention period (Core requires v3.2.0+) |
-| `delete_database` | Delete a database |
-| `execute_query` | Run SQL queries |
-| `get_measurements` | List tables in a database |
-| `get_measurement_schema` | Show columns/types for a table |
-| `write_line_protocol` | Write data via line protocol |
-| `create_admin_token` | Create named admin token |
-| `list_admin_tokens` | List admin tokens |
-| `create_resource_token` | Create scoped resource token |
-| `list_resource_tokens` | List resource tokens |
-| `delete_token` | Delete a token by name |
-| `regenerate_operator_token` | Regenerate operator token (destructive) |
-| `get_help` | Built-in help and troubleshooting |
-| `load_database_context` | Load custom context from `context/` |
+| Tool                        | Description                                     |
+| --------------------------- | ----------------------------------------------- |
+| `health_check`              | Verify connection and health status             |
+| `list_databases`            | List all databases                              |
+| `create_database`           | Create a new database                           |
+| `update_database`           | Update retention period (Core requires v3.2.0+) |
+| `delete_database`           | Delete a database                               |
+| `execute_query`             | Run SQL queries                                 |
+| `get_measurements`          | List tables in a database                       |
+| `get_measurement_schema`    | Show columns/types for a table                  |
+| `write_line_protocol`       | Write data via line protocol                    |
+| `create_admin_token`        | Create named admin token                        |
+| `list_admin_tokens`         | List admin tokens                               |
+| `create_resource_token`     | Create scoped resource token                    |
+| `list_resource_tokens`      | List resource tokens                            |
+| `delete_token`              | Delete a token by name                          |
+| `regenerate_operator_token` | Regenerate operator token (destructive)         |
+| `get_help`                  | Built-in help and troubleshooting               |
+| `load_database_context`     | Load custom context from `context/`             |
 
 For Core/Enterprise, `update_database` supports the retention period only
 (updating retention on Core requires v3.2.0+). The `cloud_*` token tools are
@@ -147,6 +148,7 @@ and `INFLUX_DB_PRODUCT_TYPE` is exactly `core` or `enterprise`.
 ### Health check fails but server starts
 
 The server can start without a reachable InfluxDB instance. Check:
+
 1. InfluxDB is running: `curl http://localhost:8181/ping`
 2. Token is valid (operator or admin token for full access)
 3. URL has trailing slash if using the default config

--- a/.claude/skills/build-run-core-enterprise/references/mcp-client-configs.md
+++ b/.claude/skills/build-run-core-enterprise/references/mcp-client-configs.md
@@ -59,11 +59,16 @@ Use `host.docker.internal` to reach InfluxDB running on the Docker host:
     "influxdb": {
       "command": "docker",
       "args": [
-        "run", "--rm", "-i",
+        "run",
+        "--rm",
+        "-i",
         "--add-host=host.docker.internal:host-gateway",
-        "-e", "INFLUX_DB_INSTANCE_URL",
-        "-e", "INFLUX_DB_TOKEN",
-        "-e", "INFLUX_DB_PRODUCT_TYPE",
+        "-e",
+        "INFLUX_DB_INSTANCE_URL",
+        "-e",
+        "INFLUX_DB_TOKEN",
+        "-e",
+        "INFLUX_DB_PRODUCT_TYPE",
         "influxdb-mcp-server"
       ],
       "env": {
@@ -87,10 +92,15 @@ When InfluxDB is on a separate host, use the remote URL directly (no
     "influxdb": {
       "command": "docker",
       "args": [
-        "run", "--rm", "-i",
-        "-e", "INFLUX_DB_INSTANCE_URL",
-        "-e", "INFLUX_DB_TOKEN",
-        "-e", "INFLUX_DB_PRODUCT_TYPE",
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "INFLUX_DB_INSTANCE_URL",
+        "-e",
+        "INFLUX_DB_TOKEN",
+        "-e",
+        "INFLUX_DB_PRODUCT_TYPE",
         "influxdb-mcp-server"
       ],
       "env": {

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -181,6 +181,59 @@ The `createTestClient(env?)` factory in `tests/helpers/mcp-client.ts` spawns
 a real server process and returns a connected MCP `Client`. Override env vars
 by passing a partial record. Always call `close()` in `afterAll`.
 
+## Reviewing data-plane and admin changes
+
+When a change adds or modifies a tool that talks to an InfluxDB endpoint
+(writes, queries, database/token management), verify the actual API contract
+and exercise it against a real instance. Tool descriptions, CHANGELOG entries,
+and code comments are not authoritative on their own — confirm them.
+
+### Verify the API contract first
+
+Confirm the HTTP method, path, and request/response shape against both the
+InfluxData docs knowledge source and the `influxdata/influxdb` source
+(`influxdb3_server/src/http.rs` routing, `influxdb3_types/src/http.rs` structs).
+
+Gotchas that have already bitten this repo:
+
+- Core/Enterprise `update_database` retention is `PUT /api/v3/configure/database`
+  with `retention_period` as a duration string (`"60d"`) — not `PATCH`, not
+  `retention_period_ns`.
+- Core can update retention since v3.2.0 (static docs wrongly say it's immutable).
+- `/ping` and `/health` use `Token` auth even for core/enterprise (v1/v2 compat);
+  the admin client uses `Bearer`. Both are intentional.
+
+### Exercise it against a real instance
+
+Admin endpoints (`/api/v3/configure/*`) need an admin token; `health_check`
+does not, so a passing `health_check` does not prove the token works. Run a
+self-contained Core for an admin-path test on a free port:
+
+```bash
+docker run -d --name mcp-it-core -p 8383:8181 \
+  -v "$PWD/tests/fixtures/admin-token.json":/admin-token.json:ro \
+  influxdb:3-core influxdb3 serve \
+  --node-id local-test --object-store memory \
+  --admin-token-file /admin-token.json
+
+INFLUX_TEST_ENABLED=true INFLUX_DB_INSTANCE_URL=http://localhost:8383/ \
+INFLUX_DB_TOKEN=apiv3_test INFLUX_DB_PRODUCT_TYPE=core \
+npx vitest run tests/integration.test.ts
+
+docker rm -f mcp-it-core
+```
+
+This uses the offline preconfigured admin token in `tests/fixtures/admin-token.json`
+(token `apiv3_test`) — the `docker-compose.test.yml` pattern, but on a port you
+choose so it does not collide with other local instances.
+
+### Token gotcha
+
+v3 tokens are base64 and can contain `+`, `/`, and `=`. Do not extract one with
+`grep -oE 'apiv3_[A-Za-z0-9_-]+'` — it truncates at the first base64 character
+and yields an invalid token (the server returns `401 "the request was not
+authenticated"`).
+
 ## Additional Resources
 
 ### Reference Files

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -87,18 +87,18 @@ Reruns on file changes. Useful during development.
 
 ## What the Tests Cover
 
-| Test | What it verifies |
-|---|---|
-| Initialize handshake | Server starts, SDK handshake succeeds, capabilities reported |
-| Server version | Name is `"influxdb-mcp-server"`, version is defined |
-| Tool count | `tools/list` returns exactly `EXPECTED_TOOL_COUNT` tools |
-| Tool structure | Each tool has `name`, `description`, `inputSchema` with `type: "object"` |
-| Core tool names | Spot-checks `health_check`, `execute_query`, `write_line_protocol`, `list_databases`, `create_admin_token` |
-| Resource URIs | 4 resources with correct `influx://` URIs |
-| Resource structure | Each resource has `name`, `uri`, `description` |
-| Prompt names | 3 prompts: `list-databases`, `check-health`, `load-context` |
-| Ping | Server responds to ping |
-| Unknown tool error | Calling nonexistent tool throws `McpError` |
+| Test                 | What it verifies                                                                                           |
+| -------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Initialize handshake | Server starts, SDK handshake succeeds, capabilities reported                                               |
+| Server version       | Name is `"influxdb-mcp-server"`, version is defined                                                        |
+| Tool count           | `tools/list` returns exactly `EXPECTED_TOOL_COUNT` tools                                                   |
+| Tool structure       | Each tool has `name`, `description`, `inputSchema` with `type: "object"`                                   |
+| Core tool names      | Spot-checks `health_check`, `execute_query`, `write_line_protocol`, `list_databases`, `create_admin_token` |
+| Resource URIs        | 4 resources with correct `influx://` URIs                                                                  |
+| Resource structure   | Each resource has `name`, `uri`, `description`                                                             |
+| Prompt names         | 3 prompts: `list-databases`, `check-health`, `load-context`                                                |
+| Ping                 | Server responds to ping                                                                                    |
+| Unknown tool error   | Calling nonexistent tool throws `McpError`                                                                 |
 
 ## Analyzing Failures
 
@@ -112,6 +112,7 @@ The most common failure after code changes. The constant in
 below for documentation.
 
 To find the current count, start the server briefly and check stderr:
+
 ```bash
 npm run build && INFLUX_DB_INSTANCE_URL=http://localhost:19999/ \
 INFLUX_DB_TOKEN=fake INFLUX_DB_PRODUCT_TYPE=core \
@@ -122,6 +123,7 @@ sleep 1 && kill $!
 Look for: `[MCP] Server initialized with N tools, N resources, N prompts`
 
 The tool count breakdown by category file:
+
 - `help.tools.ts` (2) + `write.tools.ts` (1) + `database.tools.ts` (4)
 - `query.tools.ts` (3) + `token.tools.ts` (6) + `cloud-token.tools.ts` (5)
 - `health.tools.ts` (1) = **22 total**
@@ -136,6 +138,7 @@ message if the build artifact is missing.
 ### Initialize handshake timeout
 
 The server process failed to start. Common causes:
+
 - Build is stale after source changes — rebuild with `npm run build`
 - Missing or invalid env vars — protocol tests use a fake config internally,
   so this usually means `createTestClient` was called with bad overrides
@@ -143,6 +146,7 @@ The server process failed to start. Common causes:
 ### Integration test: "HEALTHY" not found
 
 InfluxDB instance is unreachable or unhealthy. Verify:
+
 1. Instance is running: `curl http://localhost:8181/ping`
 2. Token is valid
 3. `INFLUX_DB_PRODUCT_TYPE` matches the actual instance type

--- a/.claude/skills/testing/references/test-architecture.md
+++ b/.claude/skills/testing/references/test-architecture.md
@@ -25,7 +25,7 @@ The trick: `createTestClient()` passes a fake config:
 
 ```typescript
 const BASE_ENV = {
-  INFLUX_DB_INSTANCE_URL: "http://localhost:19999/",  // nothing listens here
+  INFLUX_DB_INSTANCE_URL: "http://localhost:19999/", // nothing listens here
   INFLUX_DB_TOKEN: "test-token-not-used",
   INFLUX_DB_PRODUCT_TYPE: "core",
 };
@@ -106,7 +106,7 @@ exist, and skips gracefully if not (rather than failing on an empty instance).
 ```
 
 - **15s timeouts**: Generous for slow CI machines where child process spawn
-  + initialize handshake can take 2-3 seconds
+  - initialize handshake can take 2-3 seconds
 - **No pool override**: Default vitest forks handle child process spawning
 - **No `rootDir` change to tsconfig**: vitest uses Vite's esbuild pipeline
   to compile test files independently from `tsc`. The production tsconfig
@@ -127,6 +127,7 @@ For integration tests that need InfluxDB, use the same
 ## Local Docker Infrastructure
 
 `docker-compose.test.yml` starts InfluxDB 3 Core with:
+
 - `--object-store memory` — ephemeral, no volumes
 - Docker secrets to inject `tests/fixtures/admin-token.json` as
   `--admin-token-file=/run/secrets/admin-token`
@@ -151,6 +152,7 @@ Uses `docker run` (not `services:`) because Core requires
 cannot pass container CMD arguments.
 
 The job:
+
 1. Checks out the repo (which includes `tests/fixtures/admin-token.json`)
 2. Bind-mounts the token file into the container at `/run/secrets/admin-token`
 3. Polls `/ping` until Core is ready (up to 30 seconds)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Version consistency check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -40,11 +40,11 @@ jobs:
     name: Protocol tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
           cache: "npm"
@@ -57,11 +57,11 @@ jobs:
     name: Integration tests (InfluxDB 3 Core)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
           cache: "npm"
@@ -113,11 +113,11 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     environment: cloud-serverless
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the official InfluxDB MCP Server will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0] - 2026-06-05
 
 ### Added
 
@@ -57,7 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **InfluxDB Cloud Serverless Support**: Complete support for InfluxDB Cloud Serverless instances
-
   - Full database management with Cloud Serverless specific parameters: `description`, `retentionPeriod`
   - Support for bucket operations (Cloud Serverless databases are called "buckets")
   - Enhanced `create_database` and `update_database` tools with Cloud Serverless configuration
@@ -67,7 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New configuration files: `env.cloud-serverless.example` and `example-cloud-serverless.mcp.json`
 
 - **Custom Context System**: Optional user-provided database context and documentation
-
   - New `ContextFileService` for flexible context file discovery
   - `context-file` MCP resource exposing custom documentation via `influx://context`
   - `load-context` MCP prompt for one-click context loading
@@ -78,21 +76,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhanced
 
 - **Query Operations**:
-
   - Universal CAST requirements documentation for both Cloud Dedicated and Cloud Serverless
   - Enhanced query tools with product-specific guidance for aggregation functions
   - Proper handling of Cloud Serverless response format with `_fields` arrays
   - Updated query examples with correct CAST syntax for v3 cloud products
 
 - **Database Management**:
-
   - Cloud Serverless bucket lifecycle management (create, update, delete, list)
   - Retention period enforcement awareness and error handling
   - Product-specific parameter validation and configuration
   - Enhanced database listing with Cloud Serverless metadata
 
 - **Write Operations**:
-
   - Retention period violation handling for cloud instances
   - Improved error messages for timestamp-related write failures
   - Enhanced line protocol validation and troubleshooting guidance
@@ -116,7 +111,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **InfluxDB Cloud Dedicated Support**: Complete support for InfluxDB Cloud Dedicated clusters
-
   - New `update_database` tool for Cloud Dedicated database configuration management
   - Support for Cloud Dedicated specific parameters: `maxTables`, `maxColumnsPerTable`, `retentionPeriod`
   - Enhanced `create_database` tool with optional Cloud Dedicated configuration parameters
@@ -125,7 +119,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New configuration files: `env.cloud-dedicated.example` and `example-cloud-dedicated.mcp.json`
 
 - **Enhanced Validation System**: Comprehensive operation validation based on product type and configuration
-
   - All operations now validate required capabilities before execution
   - Product type-specific operation restrictions (e.g., token management only for Core/Enterprise)
   - Configuration validation ensures proper credentials for each operation type
@@ -140,13 +133,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhanced
 
 - **Database Management**:
-
   - `create_database` tool now supports Cloud Dedicated configuration parameters
   - `list_databases` returns Cloud Dedicated specific database metadata
   - All database operations now properly validate management capabilities
 
 - **Connection Management**:
-
   - Improved health checking with flexible endpoint assessment
   - Better connection status reporting for different InfluxDB product types
   - Enhanced error handling for Cloud Dedicated authentication scenarios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the official InfluxDB MCP Server will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Enterprise/Core Retention Policy Support**: Added database retention policy configuration for Core/Enterprise instances via `update_database` tool
+  - New method `updateDatabaseCoreEnterprise()` in `DatabaseManagementService` for PATCH `/api/v3/configure/database/{name}`
+  - Support for `retentionPeriod` parameter on Core/Enterprise (sets `retention_period_ns` field)
+  - Warning when unsupported parameters (maxTables, maxColumnsPerTable) are provided for Core/Enterprise
+  - Enhanced tool description to indicate Enterprise support for retention configuration
+
+### Enhanced
+
+- **Tool Availability**: Updated `update_database` from "Cloud Dedicated only" to "All versions"
+  - Cloud Dedicated: supports maxTables, maxColumnsPerTable, retentionPeriod
+  - Core/Enterprise: supports retentionPeriod only
+- **Documentation**: Added retention policy examples for Enterprise and common retention period reference table
+
 ## [1.1.0] - 2025-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Model Context Protocol (MCP) server for InfluxDB 3 integration. Provides tools, 
 | `get_help`                    | Get help and troubleshooting guidance for InfluxDB operations  | All versions         |
 | `write_line_protocol`         | Write data using InfluxDB line protocol                        | All versions         |
 | `create_database`             | Create a new database (with Cloud Dedicated config options)    | All versions         |
-| `update_database`             | Update database configuration (maxTables, retention, etc.)     | Cloud Dedicated only |
+| `update_database`             | Update database configuration (retention for all, maxTables/maxColumns for Cloud Dedicated) | All versions |
 | `delete_database`             | Delete a database by name (irreversible)                       | All versions         |
 | `execute_query`               | Run a SQL query against a database (supports multiple formats) | All versions         |
 | `get_measurements`            | List all measurements (tables) in a database                   | All versions         |
@@ -237,6 +237,37 @@ Use `host.docker.internal` as the InfluxDB URL so the MCP server container can r
   - `example-docker.mcp.json` - Docker-based setup
   - `example-cloud-dedicated.mcp.json` - Cloud Dedicated with all variables
 - See the `env.example` and `env.cloud-dedicated.example` files for environment variable templates.
+
+### Database Retention Policy Examples
+
+#### Core/Enterprise - Set 90-day Retention
+```typescript
+// Set 90-day retention policy on Enterprise instance
+await mcp.update_database({
+  name: "my_database",
+  retentionPeriod: 7776000000000000  // 90 days in nanoseconds
+});
+```
+
+#### Cloud Dedicated - Update Multiple Settings
+```typescript
+// Update retention, maxTables, and maxColumnsPerTable
+await mcp.update_database({
+  name: "my_database",
+  retentionPeriod: 7776000000000000,  // 90 days
+  maxTables: 1000,
+  maxColumnsPerTable: 250
+});
+```
+
+#### Common Retention Periods
+| Duration | Nanoseconds |
+|----------|-------------|
+| 7 days | 604,800,000,000,000 |
+| 30 days | 2,592,000,000,000,000 |
+| 90 days | 7,776,000,000,000,000 |
+| 180 days | 15,552,000,000,000,000 |
+| 1 year | 31,536,000,000,000,000 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # InfluxDB MCP Server
 
 [![CI](https://github.com/influxdata/influxdb3_mcp_server/actions/workflows/ci.yml/badge.svg)](https://github.com/influxdata/influxdb3_mcp_server/actions/workflows/ci.yml)
+
 <!-- [![Unit Tests](https://github.com/influxdata/influxdb3_mcp_server/actions/workflows/unit.yml/badge.svg)](https://github.com/influxdata/influxdb3_mcp_server/actions/workflows/unit.yml) -->
 <!-- [![Lint](https://github.com/influxdata/influxdb3_mcp_server/actions/workflows/lint.yml/badge.svg)](https://github.com/influxdata/influxdb3_mcp_server/actions/workflows/lint.yml) -->
+
 [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/influxdata/influxdb3_mcp_server)](https://archestra.ai/mcp-catalog/influxdata__influxdb3_mcp_server)
 
 Model Context Protocol (MCP) server for InfluxDB 3 integration. Provides tools, resources, and prompts for interacting with InfluxDB v3 (Core/Enterprise/Cloud Dedicated/Clustered/Cloud Serverless) via MCP clients.
@@ -20,30 +22,30 @@ Model Context Protocol (MCP) server for InfluxDB 3 integration. Provides tools, 
 
 ## Available Tools
 
-| Tool Name                     | Description                                                       | Availability                         |
-| ----------------------------- | ----------------------------------------------------------------- | ------------------------------------ |
-| `load_database_context`       | Load optional custom database context and documentation           | All versions                         |
-| `get_help`                    | Get help and troubleshooting guidance for InfluxDB operations     | All versions                         |
-| `write_line_protocol`         | Write data using InfluxDB line protocol                           | All versions                         |
-| `create_database`             | Create a new database (with cloud-specific config options)        | All versions                         |
-| `update_database`             | Update database configuration (retention for all; maxTables/maxColumns for Cloud Dedicated/Clustered) | All versions |
-| `delete_database`             | Delete a database by name (irreversible)                          | All versions                         |
-| `execute_query`               | Run a SQL query against a database (supports multiple formats)    | All versions                         |
-| `get_measurements`            | List all measurements (tables) in a database                      | All versions                         |
-| `get_measurement_schema`      | Get schema (columns/types) for a measurement/table                | All versions                         |
-| `create_admin_token`          | Create a new admin token (full permissions)                       | Core/Enterprise only                 |
-| `list_admin_tokens`           | List all admin tokens (with optional filtering)                   | Core/Enterprise only                 |
-| `create_resource_token`       | Create a resource token for specific DBs and permissions          | Core/Enterprise only                 |
-| `list_resource_tokens`        | List all resource tokens (with filtering and ordering)            | Core/Enterprise only                 |
-| `delete_token`                | Delete a token by name                                            | Core/Enterprise only                 |
-| `regenerate_operator_token`   | Regenerate the operator token (dangerous/irreversible)            | Core/Enterprise only                 |
-| `cloud_list_database_tokens`  | List all database tokens for Cloud-Dedicated/Clustered cluster    | Cloud Dedicated/Clustered            |
-| `cloud_get_database_token`    | Get details of a specific database token by ID                    | Cloud Dedicated/Clustered            |
-| `cloud_create_database_token` | Create a new database token for Cloud-Dedicated/Clustered cluster | Cloud Dedicated/Clustered            |
-| `cloud_update_database_token` | Update an existing database token                                 | Cloud Dedicated/Clustered            |
-| `cloud_delete_database_token` | Delete a database token from Cloud-Dedicated/Clustered cluster    | Cloud Dedicated/Clustered            |
-| `list_databases`              | List all available databases in the instance                      | All versions                         |
-| `health_check`                | Check InfluxDB connection and health status                       | All versions                         |
+| Tool Name                     | Description                                                                                           | Availability              |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------- |
+| `load_database_context`       | Load optional custom database context and documentation                                               | All versions              |
+| `get_help`                    | Get help and troubleshooting guidance for InfluxDB operations                                         | All versions              |
+| `write_line_protocol`         | Write data using InfluxDB line protocol                                                               | All versions              |
+| `create_database`             | Create a new database (with cloud-specific config options)                                            | All versions              |
+| `update_database`             | Update database configuration (retention for all; maxTables/maxColumns for Cloud Dedicated/Clustered) | All versions              |
+| `delete_database`             | Delete a database by name (irreversible)                                                              | All versions              |
+| `execute_query`               | Run a SQL query against a database (supports multiple formats)                                        | All versions              |
+| `get_measurements`            | List all measurements (tables) in a database                                                          | All versions              |
+| `get_measurement_schema`      | Get schema (columns/types) for a measurement/table                                                    | All versions              |
+| `create_admin_token`          | Create a new admin token (full permissions)                                                           | Core/Enterprise only      |
+| `list_admin_tokens`           | List all admin tokens (with optional filtering)                                                       | Core/Enterprise only      |
+| `create_resource_token`       | Create a resource token for specific DBs and permissions                                              | Core/Enterprise only      |
+| `list_resource_tokens`        | List all resource tokens (with filtering and ordering)                                                | Core/Enterprise only      |
+| `delete_token`                | Delete a token by name                                                                                | Core/Enterprise only      |
+| `regenerate_operator_token`   | Regenerate the operator token (dangerous/irreversible)                                                | Core/Enterprise only      |
+| `cloud_list_database_tokens`  | List all database tokens for Cloud-Dedicated/Clustered cluster                                        | Cloud Dedicated/Clustered |
+| `cloud_get_database_token`    | Get details of a specific database token by ID                                                        | Cloud Dedicated/Clustered |
+| `cloud_create_database_token` | Create a new database token for Cloud-Dedicated/Clustered cluster                                     | Cloud Dedicated/Clustered |
+| `cloud_update_database_token` | Update an existing database token                                                                     | Cloud Dedicated/Clustered |
+| `cloud_delete_database_token` | Delete a database token from Cloud-Dedicated/Clustered cluster                                        | Cloud Dedicated/Clustered |
+| `list_databases`              | List all available databases in the instance                                                          | All versions              |
+| `health_check`                | Check InfluxDB connection and health status                                                           | All versions              |
 
 ---
 
@@ -306,33 +308,36 @@ Use `host.docker.internal` as the InfluxDB URL so the MCP server container can r
 ### Database Retention Policy Examples
 
 #### Core/Enterprise - Set 90-day Retention
+
 ```typescript
 // Set 90-day retention policy on Enterprise instance
 await mcp.update_database({
   name: "my_database",
-  retentionPeriod: 7776000000000000  // 90 days in nanoseconds
+  retentionPeriod: 7776000000000000, // 90 days in nanoseconds
 });
 ```
 
 #### Cloud Dedicated - Update Multiple Settings
+
 ```typescript
 // Update retention, maxTables, and maxColumnsPerTable
 await mcp.update_database({
   name: "my_database",
-  retentionPeriod: 7776000000000000,  // 90 days
+  retentionPeriod: 7776000000000000, // 90 days
   maxTables: 1000,
-  maxColumnsPerTable: 250
+  maxColumnsPerTable: 250,
 });
 ```
 
 #### Common Retention Periods
-| Duration | Nanoseconds |
-|----------|-------------|
-| 7 days | 604,800,000,000,000 |
-| 30 days | 2,592,000,000,000,000 |
-| 90 days | 7,776,000,000,000,000 |
+
+| Duration | Nanoseconds            |
+| -------- | ---------------------- |
+| 7 days   | 604,800,000,000,000    |
+| 30 days  | 2,592,000,000,000,000  |
+| 90 days  | 7,776,000,000,000,000  |
 | 180 days | 15,552,000,000,000,000 |
-| 1 year | 31,536,000,000,000,000 |
+| 1 year   | 31,536,000,000,000,000 |
 
 ---
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,7 +12,15 @@ services:
     secrets:
       - admin-token
     healthcheck:
-      test: ["CMD", "curl", "-f", "-H", "Authorization: Bearer apiv3_test", "http://localhost:8181/ping"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "-H",
+          "Authorization: Bearer apiv3_test",
+          "http://localhost:8181/ping",
+        ]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@influxdata/influxdb3-mcp-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@influxdata/influxdb3-mcp-server",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@influxdata/influxdb3-client": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/influxdb3-mcp-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Official InfluxDB MCP server for Model Context Protocol integration",
   "license": "(Apache-2.0 OR MIT)",
   "private": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,7 +45,7 @@ export function loadConfig(): McpServerConfig {
     },
     server: {
       name: "influxdb-mcp-server",
-      version: "1.3.0",
+      version: "1.4.0",
     },
   };
 }

--- a/src/services/database-management.service.ts
+++ b/src/services/database-management.service.ts
@@ -359,7 +359,8 @@ export class DatabaseManagementService {
 
   /**
    * Update database configuration for core/enterprise
-   * Only supports retentionPeriod (retention_period_ns)
+   * Only supports retentionPeriod (retention_period)
+   * Uses PUT /api/v3/configure/database with db and retention_period in body
    */
   private async updateDatabaseCoreEnterprise(
     name: string,
@@ -367,13 +368,15 @@ export class DatabaseManagementService {
   ): Promise<boolean> {
     try {
       const httpClient = this.baseService.getInfluxHttpClient();
-      const endpoint = `/api/v3/configure/database/${encodeURIComponent(name)}`;
+      const endpoint = `/api/v3/configure/database`;
 
-      const payload: any = {};
+      const payload: any = {
+        db: name
+      };
 
-      // Core/Enterprise only supports retention_period_ns
+      // Core/Enterprise only supports retention_period (not retention_period_ns)
       if (config.retentionPeriod !== undefined) {
-        payload.retention_period_ns = config.retentionPeriod;
+        payload.retention_period = this.formatRetentionPeriod(config.retentionPeriod);
       }
 
       // Warn if unsupported parameters are provided
@@ -383,17 +386,38 @@ export class DatabaseManagementService {
         );
       }
 
-      if (Object.keys(payload).length === 0) {
+      if (!payload.retention_period) {
         throw new Error(
           "No valid configuration parameters provided for Core/Enterprise update. Only retentionPeriod is supported."
         );
       }
 
-      await httpClient.patch(endpoint, payload);
+      await httpClient.put(endpoint, payload);
       return true;
     } catch (error: any) {
       this.handleDatabaseError(error, `update database '${name}'`);
     }
+  }
+
+  /**
+   * Format retention period from nanoseconds to duration string (e.g., "7d", "1y")
+   */
+  private formatRetentionPeriod(retentionPeriodNs: number): string {
+    const seconds = retentionPeriodNs / 1_000_000_000;
+    const days = seconds / (24 * 60 * 60);
+    
+    // If exactly divisible by 365.25, use years
+    if (days >= 365.25 && days % 365.25 === 0) {
+      return `${Math.floor(days / 365.25)}y`;
+    }
+    
+    // If exactly divisible by 30, use months (approximately)
+    if (days >= 30 && days % 30 === 0) {
+      return `${Math.floor(days / 30)}mo`;
+    }
+    
+    // Otherwise use days
+    return `${Math.floor(days)}d`;
   }
 
   /**

--- a/src/services/database-management.service.ts
+++ b/src/services/database-management.service.ts
@@ -77,17 +77,15 @@ export class DatabaseManagementService {
   }
 
   /**
-   * Update database configuration (only for cloud-dedicated)
-   * PATCH /api/v0/accounts/{account_id}/clusters/{cluster_id}/databases/{name}
+   * Update database configuration
+   * For cloud-dedicated: PATCH /api/v0/accounts/{account_id}/clusters/{cluster_id}/databases/{name}
+   * For core/enterprise: PATCH /api/v3/configure/database/{name}
    */
   async updateDatabase(
     name: string,
     config: Partial<CloudDedicatedDatabaseConfig>,
   ): Promise<boolean> {
     if (!name) throw new Error("Database name is required");
-    this.baseService.validateOperationSupport("update_database", [
-      InfluxProductType.CloudDedicated,
-    ]);
     this.baseService.validateManagementCapabilities();
 
     const connectionInfo = this.baseService.getConnectionInfo();
@@ -96,9 +94,7 @@ export class DatabaseManagementService {
         return this.updateDatabaseCloudDedicated(name, config);
       case InfluxProductType.Core:
       case InfluxProductType.Enterprise:
-        throw new Error(
-          "Database update is not supported for core/enterprise InfluxDB",
-        );
+        return this.updateDatabaseCoreEnterprise(name, config);
       default:
         throw new Error(
           `Unsupported InfluxDB product type: ${connectionInfo.type}`,
@@ -358,6 +354,45 @@ export class DatabaseManagementService {
       return true;
     } catch (error: any) {
       this.handleDatabaseError(error, `delete database '${name}'`);
+    }
+  }
+
+  /**
+   * Update database configuration for core/enterprise
+   * Only supports retentionPeriod (retention_period_ns)
+   */
+  private async updateDatabaseCoreEnterprise(
+    name: string,
+    config: Partial<CloudDedicatedDatabaseConfig>,
+  ): Promise<boolean> {
+    try {
+      const httpClient = this.baseService.getInfluxHttpClient();
+      const endpoint = `/api/v3/configure/database/${encodeURIComponent(name)}`;
+
+      const payload: any = {};
+
+      // Core/Enterprise only supports retention_period_ns
+      if (config.retentionPeriod !== undefined) {
+        payload.retention_period_ns = config.retentionPeriod;
+      }
+
+      // Warn if unsupported parameters are provided
+      if (config.maxTables !== undefined || config.maxColumnsPerTable !== undefined) {
+        console.warn(
+          "Warning: maxTables and maxColumnsPerTable are not supported for Core/Enterprise. Only retentionPeriod is supported."
+        );
+      }
+
+      if (Object.keys(payload).length === 0) {
+        throw new Error(
+          "No valid configuration parameters provided for Core/Enterprise update. Only retentionPeriod is supported."
+        );
+      }
+
+      await httpClient.patch(endpoint, payload);
+      return true;
+    } catch (error: any) {
+      this.handleDatabaseError(error, `update database '${name}'`);
     }
   }
 

--- a/src/tools/categories/database.tools.ts
+++ b/src/tools/categories/database.tools.ts
@@ -123,7 +123,7 @@ export function createDatabaseTools(
     {
       name: "update_database",
       description:
-        "Update database configuration for InfluxDB Cloud Dedicated clusters only. Allows modification of maxTables, maxColumnsPerTable, and retentionPeriod settings. Not available for Core/Enterprise installations.",
+        "Update database configuration for InfluxDB. For Cloud Dedicated: modify maxTables, maxColumnsPerTable, and retentionPeriod. For Core/Enterprise: modify retentionPeriod only (retention_period_ns). Not available for Cloud Serverless.",
       inputSchema: {
         type: "object",
         properties: {
@@ -133,17 +133,17 @@ export function createDatabaseTools(
           },
           maxTables: {
             type: "number",
-            description: "Maximum number of tables (optional)",
+            description: "Maximum number of tables (Cloud Dedicated only)",
             minimum: 1,
           },
           maxColumnsPerTable: {
             type: "number",
-            description: "Maximum columns per table (optional)",
+            description: "Maximum columns per table (Cloud Dedicated only)",
             minimum: 1,
           },
           retentionPeriod: {
             type: "number",
-            description: "Retention period in nanoseconds (optional)",
+            description: "Retention period in nanoseconds (Cloud Dedicated and Core/Enterprise)",
             minimum: 0,
           },
         },
@@ -156,17 +156,17 @@ export function createDatabaseTools(
           .number()
           .min(1)
           .optional()
-          .describe("Maximum number of tables"),
+          .describe("Maximum number of tables (Cloud Dedicated only)"),
         maxColumnsPerTable: z
           .number()
           .min(1)
           .optional()
-          .describe("Maximum columns per table"),
+          .describe("Maximum columns per table (Cloud Dedicated only)"),
         retentionPeriod: z
           .number()
           .min(0)
           .optional()
-          .describe("Retention period in nanoseconds"),
+          .describe("Retention period in nanoseconds (Cloud Dedicated and Core/Enterprise)"),
       }),
       handler: async (args) => {
         try {

--- a/tests/database-update-retention.test.ts
+++ b/tests/database-update-retention.test.ts
@@ -59,7 +59,9 @@ describe("updateDatabase – Core/Enterprise retention", () => {
     const { svc, put } = serviceWithPut(base);
 
     // 90 minutes -> floors to 1h (never 0d)
-    await svc.updateDatabase("mydb", { retentionPeriod: 90 * 60 * 1_000_000_000 });
+    await svc.updateDatabase("mydb", {
+      retentionPeriod: 90 * 60 * 1_000_000_000,
+    });
 
     expect(put.mock.calls[0][1].retention_period).toBe("1h");
   });

--- a/tests/helpers/mcp-client.ts
+++ b/tests/helpers/mcp-client.ts
@@ -25,9 +25,7 @@ export async function createTestClient(
     stderr: "pipe",
   });
 
-  const client = new Client(
-    { name: "test-client", version: "1.0.0" },
-  );
+  const client = new Client({ name: "test-client", version: "1.0.0" });
 
   await client.connect(transport);
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -5,14 +5,25 @@ const RUN =
   process.env.INFLUX_TEST_ENABLED === "true" ||
   process.env.INFLUX_TEST_ENABLED === "1";
 
+// Retention configuration via update_database is only supported on Core and
+// Enterprise, which use the v3 API. Skip the retention test for other product
+// types (for example the Cloud Serverless CI job, which manages buckets through
+// the v2 API and has no retention_period update path).
+const PRODUCT_TYPE = process.env.INFLUX_DB_PRODUCT_TYPE ?? "core";
+const RETENTION_SUPPORTED =
+  PRODUCT_TYPE === "core" || PRODUCT_TYPE === "enterprise";
+
 describe.skipIf(!RUN)("live InfluxDB integration", () => {
   let testClient: TestClient;
 
   beforeAll(async () => {
     const env: Record<string, string> = {};
-    if (process.env.INFLUX_DB_INSTANCE_URL) env.INFLUX_DB_INSTANCE_URL = process.env.INFLUX_DB_INSTANCE_URL;
-    if (process.env.INFLUX_DB_TOKEN) env.INFLUX_DB_TOKEN = process.env.INFLUX_DB_TOKEN;
-    if (process.env.INFLUX_DB_PRODUCT_TYPE) env.INFLUX_DB_PRODUCT_TYPE = process.env.INFLUX_DB_PRODUCT_TYPE;
+    if (process.env.INFLUX_DB_INSTANCE_URL)
+      env.INFLUX_DB_INSTANCE_URL = process.env.INFLUX_DB_INSTANCE_URL;
+    if (process.env.INFLUX_DB_TOKEN)
+      env.INFLUX_DB_TOKEN = process.env.INFLUX_DB_TOKEN;
+    if (process.env.INFLUX_DB_PRODUCT_TYPE)
+      env.INFLUX_DB_PRODUCT_TYPE = process.env.INFLUX_DB_PRODUCT_TYPE;
     testClient = await createTestClient(env);
   });
 
@@ -73,35 +84,38 @@ describe.skipIf(!RUN)("live InfluxDB integration", () => {
     expect((result as { isError?: boolean }).isError).not.toBe(true);
   });
 
-  it("update_database sets a retention period (Core/Enterprise)", async () => {
-    const dbName = "mcp_it_retention";
-    const SEVEN_DAYS_NS = 7 * 24 * 60 * 60 * 1_000_000_000;
+  it.skipIf(!RETENTION_SUPPORTED)(
+    "update_database sets a retention period (Core/Enterprise)",
+    async () => {
+      const dbName = "mcp_it_retention";
+      const SEVEN_DAYS_NS = 7 * 24 * 60 * 60 * 1_000_000_000;
 
-    // Clean slate in case a previous run left the database behind.
-    await testClient.client.callTool({
-      name: "delete_database",
-      arguments: { name: dbName },
-    });
+      // Clean slate in case a previous run left the database behind.
+      await testClient.client.callTool({
+        name: "delete_database",
+        arguments: { name: dbName },
+      });
 
-    const created = await testClient.client.callTool({
-      name: "create_database",
-      arguments: { name: dbName },
-    });
-    expect((created as { isError?: boolean }).isError).not.toBe(true);
+      const created = await testClient.client.callTool({
+        name: "create_database",
+        arguments: { name: dbName },
+      });
+      expect((created as { isError?: boolean }).isError).not.toBe(true);
 
-    const updated = await testClient.client.callTool({
-      name: "update_database",
-      arguments: { name: dbName, retentionPeriod: SEVEN_DAYS_NS },
-    });
-    const text = (updated.content as Array<{ type: string; text: string }>)[0]
-      ?.text;
-    expect((updated as { isError?: boolean }).isError).not.toBe(true);
-    expect(text).toContain("updated successfully");
+      const updated = await testClient.client.callTool({
+        name: "update_database",
+        arguments: { name: dbName, retentionPeriod: SEVEN_DAYS_NS },
+      });
+      const text = (updated.content as Array<{ type: string; text: string }>)[0]
+        ?.text;
+      expect((updated as { isError?: boolean }).isError).not.toBe(true);
+      expect(text).toContain("updated successfully");
 
-    // Cleanup.
-    await testClient.client.callTool({
-      name: "delete_database",
-      arguments: { name: dbName },
-    });
-  });
+      // Cleanup.
+      await testClient.client.callTool({
+        name: "delete_database",
+        arguments: { name: dbName },
+      });
+    },
+  );
 });

--- a/tests/query-error-core.test.ts
+++ b/tests/query-error-core.test.ts
@@ -29,9 +29,7 @@ describe("handleQueryError – Core (axios) error path", () => {
     );
     const svc = new QueryService(base);
 
-    await expect(
-      svc.executeQuery("SELECT 1", "nonexistent"),
-    ).rejects.toThrow(
+    await expect(svc.executeQuery("SELECT 1", "nonexistent")).rejects.toThrow(
       /^Database not found: query error: database not found: nonexistent$/,
     );
   });
@@ -43,9 +41,7 @@ describe("handleQueryError – Core (axios) error path", () => {
     );
     const svc = new QueryService(base);
 
-    await expect(
-      svc.executeQuery("SELECT 1", "mydb"),
-    ).rejects.toThrow(
+    await expect(svc.executeQuery("SELECT 1", "mydb")).rejects.toThrow(
       /^Bad request: partial write of line protocol occurred$/,
     );
   });
@@ -57,8 +53,8 @@ describe("handleQueryError – Core (axios) error path", () => {
     );
     const svc = new QueryService(base);
 
-    await expect(
-      svc.executeQuery("THIS IS NOT SQL", "mydb"),
-    ).rejects.toThrow(/^Query failed:.*ParserError.*Expected: an SQL statement/);
+    await expect(svc.executeQuery("THIS IS NOT SQL", "mydb")).rejects.toThrow(
+      /^Query failed:.*ParserError.*Expected: an SQL statement/,
+    );
   });
 });

--- a/tests/query-error-integration.test.ts
+++ b/tests/query-error-integration.test.ts
@@ -5,71 +5,69 @@ const RUN =
   process.env.INFLUX_TEST_ENABLED === "true" ||
   process.env.INFLUX_TEST_ENABLED === "1";
 
-describe.skipIf(!RUN)(
-  "error path integration tests (live Core)",
-  () => {
-    let testClient: TestClient;
+describe.skipIf(!RUN)("error path integration tests (live Core)", () => {
+  let testClient: TestClient;
 
-    beforeAll(async () => {
-      const env: Record<string, string> = {};
-      if (process.env.INFLUX_DB_INSTANCE_URL) env.INFLUX_DB_INSTANCE_URL = process.env.INFLUX_DB_INSTANCE_URL;
-      if (process.env.INFLUX_DB_TOKEN) env.INFLUX_DB_TOKEN = process.env.INFLUX_DB_TOKEN;
-      if (process.env.INFLUX_DB_PRODUCT_TYPE) env.INFLUX_DB_PRODUCT_TYPE = process.env.INFLUX_DB_PRODUCT_TYPE;
-      testClient = await createTestClient(env);
+  beforeAll(async () => {
+    const env: Record<string, string> = {};
+    if (process.env.INFLUX_DB_INSTANCE_URL)
+      env.INFLUX_DB_INSTANCE_URL = process.env.INFLUX_DB_INSTANCE_URL;
+    if (process.env.INFLUX_DB_TOKEN)
+      env.INFLUX_DB_TOKEN = process.env.INFLUX_DB_TOKEN;
+    if (process.env.INFLUX_DB_PRODUCT_TYPE)
+      env.INFLUX_DB_PRODUCT_TYPE = process.env.INFLUX_DB_PRODUCT_TYPE;
+    testClient = await createTestClient(env);
+  });
+
+  afterAll(async () => {
+    await testClient?.close();
+  });
+
+  it("execute_query on nonexistent database surfaces real error", async () => {
+    const result = await testClient.client.callTool({
+      name: "execute_query",
+      arguments: {
+        database: "nonexistent_db_xyz",
+        query: "SELECT 1",
+      },
     });
 
-    afterAll(async () => {
-      await testClient?.close();
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      ?.text;
+
+    expect(text).toMatch(/database not found/i);
+    expect(text).not.toMatch("Internal Server Error");
+  });
+
+  it("execute_query with invalid SQL surfaces parser error", async () => {
+    const dbResult = await testClient.client.callTool({
+      name: "list_databases",
+      arguments: {},
+    });
+    const dbText = (
+      dbResult.content as Array<{ type: string; text: string }>
+    )[0]?.text;
+
+    if (dbText?.includes("Found 0 databases")) {
+      return;
+    }
+
+    const dbMatch = dbText?.match(/"name":\s*"([^"]+)"/);
+    if (!dbMatch) {
+      return;
+    }
+
+    const result = await testClient.client.callTool({
+      name: "execute_query",
+      arguments: {
+        database: dbMatch[1],
+        query: "THIS IS NOT SQL",
+      },
     });
 
-    it("execute_query on nonexistent database surfaces real error", async () => {
-      const result = await testClient.client.callTool({
-        name: "execute_query",
-        arguments: {
-          database: "nonexistent_db_xyz",
-          query: "SELECT 1",
-        },
-      });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      ?.text;
 
-      const text = (
-        result.content as Array<{ type: string; text: string }>
-      )[0]?.text;
-
-      expect(text).toMatch(/database not found/i);
-      expect(text).not.toMatch("Internal Server Error");
-    });
-
-    it("execute_query with invalid SQL surfaces parser error", async () => {
-      const dbResult = await testClient.client.callTool({
-        name: "list_databases",
-        arguments: {},
-      });
-      const dbText = (
-        dbResult.content as Array<{ type: string; text: string }>
-      )[0]?.text;
-
-      if (dbText?.includes("Found 0 databases")) {
-        return;
-      }
-
-      const dbMatch = dbText?.match(/"name":\s*"([^"]+)"/);
-      if (!dbMatch) {
-        return;
-      }
-
-      const result = await testClient.client.callTool({
-        name: "execute_query",
-        arguments: {
-          database: dbMatch[1],
-          query: "THIS IS NOT SQL",
-        },
-      });
-
-      const text = (
-        result.content as Array<{ type: string; text: string }>
-      )[0]?.text;
-
-      expect(text).toMatch(/ParserError|SQL error/i);
-    });
-  },
-);
+    expect(text).toMatch(/ParserError|SQL error/i);
+  });
+});

--- a/tests/query-error-serverless.test.ts
+++ b/tests/query-error-serverless.test.ts
@@ -52,9 +52,9 @@ describe("handleQueryError – Cloud Serverless (SDK async iterator)", () => {
     );
     const svc = new QueryService(base);
 
-    await expect(
-      svc.executeQuery("SELECT 1", "mybucket"),
-    ).rejects.toThrow(/unknown query type/);
+    await expect(svc.executeQuery("SELECT 1", "mybucket")).rejects.toThrow(
+      /unknown query type/,
+    );
   });
 
   it("404: surfaces error message from SDK HttpError", async () => {
@@ -64,9 +64,9 @@ describe("handleQueryError – Cloud Serverless (SDK async iterator)", () => {
     );
     const svc = new QueryService(base);
 
-    await expect(
-      svc.executeQuery("SELECT 1", "nonexistent"),
-    ).rejects.toThrow(/could not find bucket/);
+    await expect(svc.executeQuery("SELECT 1", "nonexistent")).rejects.toThrow(
+      /could not find bucket/,
+    );
   });
 });
 
@@ -82,9 +82,9 @@ describe("handleQueryError – Serverless {code,message} via axios path", () => 
     );
     const svc = new QueryService(base);
 
-    await expect(
-      svc.executeQuery("SELECT 1", "mydb"),
-    ).rejects.toThrow(/unknown query type/);
+    await expect(svc.executeQuery("SELECT 1", "mydb")).rejects.toThrow(
+      /unknown query type/,
+    );
   });
 
   it("404: surfaces message from {code, message} JSON response", async () => {
@@ -94,8 +94,8 @@ describe("handleQueryError – Serverless {code,message} via axios path", () => 
     );
     const svc = new QueryService(base);
 
-    await expect(
-      svc.executeQuery("SELECT 1", "nonexistent"),
-    ).rejects.toThrow(/could not find bucket/);
+    await expect(svc.executeQuery("SELECT 1", "nonexistent")).rejects.toThrow(
+      /could not find bucket/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Supersedes #56. That PR is from a fork with maintainer edits disabled, so this branch carries the same work, synced with `main` and with the review findings resolved.

Adds retention-period support to `update_database` for InfluxDB 3 Core and Enterprise, and merges the v1.3.0 changes from `main` (test infrastructure, error-handling, Cloud Serverless/Clustered support).

## Review findings addressed

- **[P1] Restore Clustered and Cloud Serverless update paths.** The original branch predated the Cloud Serverless/Clustered work, so its `updateDatabase` switch dropped those cases. Merging `main` reinstates them; `update_database` now validates all five product types and routes each correctly.
- **[P1] Core/Enterprise update contract.** Verified against the InfluxDB source and a live Core 3.9.3 instance: the endpoint is `PUT /api/v3/configure/database` with `retention_period` as a humantime duration string (for example `"60d"`) — not `PATCH`, and not a `retention_period_ns` field. The code was already correct; the CHANGELOG, README, tool description, and code comments were not. They now match the contract.
- **[P2] `formatRetentionPeriod` data loss.** A sub-day period rounded down to `"0d"`, which marks all data for immediate deletion. It now emits whole days when evenly divisible, otherwise whole hours, and rejects periods shorter than one hour.

## Verification

- New unit tests assert the exact `PUT` payload, the day/hour formatting, and the `1h`-not-`0d` regression (8 tests).
- New gated integration test creates a database, updates its retention, and cleans up against a live Core instance. Run locally against Core 3.9.3: passing.
- A manual `PUT … "60d"` returned HTTP 200 on Core 3.9.3.
- `npm run build`, `npm run lint`, and the protocol tests pass.

## Notes

- Updating retention on **Core** requires v3.2.0+. The static Core docs still say retention is immutable; that documentation lags the v3.2.0 release. Verified working on 3.9.3.
- `maxTables` / `maxColumnsPerTable` remain Cloud Dedicated/Clustered only; they are ignored (with a warning) on Core/Enterprise.
- Updated the `build-run-core-enterprise` skill, which previously stated `update_database` was unavailable for Core/Enterprise.
- Testing this PR also revealed #60 
