### PR TITLE
ci: add prettier format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,22 @@ jobs:
           fi
           echo "All versions match: $PKG_VERSION"
 
+  format-check:
+    name: Format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+      - run: npm run format:check
+
   test-protocol:
     name: Protocol tests
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+build/
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean": "rm -rf build",
     "lint": "eslint . --ext .ts,.js",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "prepublishOnly": "npm run clean && npm run build",
     "pretest": "npm run build",
     "test": "vitest run",


### PR DESCRIPTION
## What this does

Adds a CI gate so prettier formatting drift is caught on every PR. #59 added the repo-local `.prettierrc.json` and normalized the tree; this PR enforces it going forward.

- New `format-check` job in `ci.yml` runs `npm run format:check` (`prettier --check .`). It reuses the same SHA-pinned `actions/checkout` and `actions/setup-node` as the other jobs.
- New `format:check` npm script.
- New `.prettierignore` for `build/`, `node_modules/`, and the generated `package-lock.json`.

## Why

The repo had no local prettier config, so `prettier --write .` inherited an ancestor config and could reformat the whole tree. #59 pinned a local config; without a CI check, nothing prevents future drift.

## Verification

`npm run format:check` passes locally: `All matched files use Prettier code style!`