### PR TITLE
ci: trigger CI on merge_group so the merge queue can complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 jobs:
@@ -123,9 +124,12 @@ jobs:
     runs-on: ubuntu-latest
     # Skip on forked PRs — environment secrets (INFLUXDB_CLOUD_URL/TOKEN) are
     # not exposed to fork runs, which would fail on empty credentials.
+    # merge_group runs only happen for same-repo branches that already
+    # cleared review, so they're always safe to include here.
     if: |
       github.repository_owner == 'influxdata' &&
       (github.event_name == 'push' ||
+       github.event_name == 'merge_group' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     environment: cloud-serverless
     steps:


### PR DESCRIPTION
## Summary

The default-branch ruleset requires the GitHub Merge Queue and requires this
workflow's `Integration tests (InfluxDB 3 Core)`, `Integration tests (InfluxDB
Cloud Serverless)`, and `Protocol tests` jobs as status checks. The queue runs
checks against temporary `gh-readonly-queue/main/*` branches, which only
trigger workflows that opt in via the `merge_group` event. `ci.yml` only had
`push` and `pull_request` triggers, so no run ever started for queued
entries — they sat in `AWAITING_CHECKS` indefinitely, waiting on required
checks that could never execute. Confirmed via the GitHub API: zero Actions
runs exist on any `gh-readonly-queue/*` branch, and `mergeQueue.entries` sat
non-empty with every entry stuck at `AWAITING_CHECKS`.

- Add `merge_group:` to the workflow's `on:` triggers.
- Extend `test-integration-cloud-serverless`'s forked-PR guard
  (`if: github.event_name == 'push' || ...`) to also allow
  `github.event_name == 'merge_group'`. Without this, the job would run on
  queue events but immediately evaluate its `if` to false and report
  skipped — leaving one of the three required checks permanently
  unsatisfied on queue runs, same symptom as before.

Related: the ruleset previously also had a `required_deployments` rule with
an empty environment list, which independently blocked the queue with
"Pull request cannot be added to a merge queue that requires deployments
before merging." That's already been removed from the ruleset directly
(no deployment workflow exists in this repo — the `cloud-serverless`
environment only scopes a test secret, which GitHub's UI mislabels as a
"deployment").

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `zizmor .github/workflows/ci.yml` — only pre-existing, unrelated
      excessive-permissions warnings
- [ ] Once merged, confirm the currently-queued PRs (#72, #73, #76, #77, #78,
      #79, #80) actually progress past `AWAITING_CHECKS`