### PR TITLE
fix: enforce outer query limits

### DIFF
--- a/src/services/query-safety.service.ts
+++ b/src/services/query-safety.service.ts
@@ -98,22 +98,19 @@ export class QuerySafetyService {
     }
 
     let normalizedQuery = trimmed.replace(/;+$/u, "");
-    const limit = this.limitValue(normalizedQuery);
+    const limit = this.topLevelLimit(normalizedQuery);
     if (this.shouldEnforceLimit(firstKeyword)) {
       if (limit === undefined) {
-        normalizedQuery = `${normalizedQuery} LIMIT ${maxRows}`;
+        normalizedQuery = this.appendLimit(normalizedQuery, maxRows);
         warnings.push({
           code: "limit_added",
           message: `Added LIMIT ${maxRows} to enforce a bounded result set.`,
         });
-      } else if (limit > maxRows) {
-        normalizedQuery = normalizedQuery.replace(
-          /\blimit\s+\d+\b/iu,
-          `LIMIT ${maxRows}`,
-        );
+      } else if (limit.value > maxRows) {
+        normalizedQuery = `${normalizedQuery.slice(0, limit.valueStart)}${maxRows}${normalizedQuery.slice(limit.valueEnd)}`;
         warnings.push({
           code: "limit_reduced",
-          message: `Reduced LIMIT ${limit} to ${maxRows}.`,
+          message: `Reduced LIMIT ${limit.value} to ${maxRows}.`,
         });
       }
     }
@@ -173,8 +170,100 @@ export class QuerySafetyService {
     return firstKeyword === "SELECT" || firstKeyword === "WITH";
   }
 
-  private limitValue(query: string): number | undefined {
-    const value = query.match(/\blimit\s+(\d+)\b/iu)?.[1];
-    return value ? Number(value) : undefined;
+  private topLevelLimit(
+    query: string,
+  ): { value: number; valueStart: number; valueEnd: number } | undefined {
+    let depth = 0;
+
+    for (let index = 0; index < query.length; ) {
+      const character = query[index];
+      const next = query[index + 1];
+
+      if (character === "'" || character === '"' || character === "`") {
+        index = this.skipQuoted(query, index, character);
+      } else if (character === "-" && next === "-") {
+        index = query.indexOf("\n", index + 2);
+        if (index === -1) return undefined;
+      } else if (character === "/" && next === "*") {
+        const end = query.indexOf("*/", index + 2);
+        index = end === -1 ? query.length : end + 2;
+      } else if (character === "(") {
+        depth += 1;
+        index += 1;
+      } else if (character === ")") {
+        depth = Math.max(0, depth - 1);
+        index += 1;
+      } else if (
+        depth === 0 &&
+        query.slice(index, index + 5).toUpperCase() === "LIMIT" &&
+        !this.isIdentifierCharacter(query[index - 1]) &&
+        !this.isIdentifierCharacter(query[index + 5])
+      ) {
+        let valueStart = index + 5;
+        while (/\s/u.test(query[valueStart] ?? "")) valueStart += 1;
+        const valueEnd = this.readDigits(query, valueStart);
+        if (valueEnd > valueStart) {
+          return {
+            value: Number(query.slice(valueStart, valueEnd)),
+            valueStart,
+            valueEnd,
+          };
+        }
+        index += 5;
+      } else {
+        index += 1;
+      }
+    }
+
+    return undefined;
+  }
+
+  private skipQuoted(query: string, start: number, quote: string): number {
+    for (let index = start + 1; index < query.length; index += 1) {
+      if (query[index] !== quote) continue;
+      if (query[index + 1] === quote) {
+        index += 1;
+        continue;
+      }
+      return index + 1;
+    }
+    return query.length;
+  }
+
+  private appendLimit(query: string, maxRows: number): string {
+    const separator = this.endsInLineComment(query) ? "\n" : " ";
+    return `${query}${separator}LIMIT ${maxRows}`;
+  }
+
+  private endsInLineComment(query: string): boolean {
+    for (let index = 0; index < query.length; ) {
+      const character = query[index];
+      const next = query[index + 1];
+
+      if (character === "'" || character === '"' || character === "`") {
+        index = this.skipQuoted(query, index, character);
+      } else if (character === "-" && next === "-") {
+        const end = query.indexOf("\n", index + 2);
+        if (end === -1) return true;
+        index = end + 1;
+      } else if (character === "/" && next === "*") {
+        const end = query.indexOf("*/", index + 2);
+        index = end === -1 ? query.length : end + 2;
+      } else {
+        index += 1;
+      }
+    }
+
+    return false;
+  }
+
+  private isIdentifierCharacter(character: string | undefined): boolean {
+    return !!character && /[A-Za-z0-9_$]/u.test(character);
+  }
+
+  private readDigits(query: string, start: number): number {
+    let end = start;
+    while (/\d/u.test(query[end] ?? "")) end += 1;
+    return end;
   }
 }

--- a/tests/query-safety.test.ts
+++ b/tests/query-safety.test.ts
@@ -42,6 +42,52 @@ describe("QuerySafetyService", () => {
     );
   });
 
+  it.each(["sql", "influxql"] as const)(
+    "adds an outer limit when a nested %s query is the only bounded query",
+    (language) => {
+      const query =
+        language === "sql"
+          ? "SELECT * FROM metrics WHERE host IN (SELECT host FROM hosts LIMIT 1)"
+          : "SELECT * FROM (SELECT * FROM metrics LIMIT 1)";
+
+      const result = service.validate(query, language, 25);
+
+      expect(result.normalizedQuery).toBe(`${query} LIMIT 25`);
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({ code: "limit_added" }),
+      );
+    },
+  );
+
+  it("only reduces the outer SQL limit", () => {
+    const result = service.validate(
+      "SELECT * FROM (SELECT * FROM metrics LIMIT 1000) LIMIT 100",
+      "sql",
+      25,
+    );
+
+    expect(result.normalizedQuery).toBe(
+      "SELECT * FROM (SELECT * FROM metrics LIMIT 1000) LIMIT 25",
+    );
+  });
+
+  it("does not treat limits in strings, comments, or identifiers as outer limits", () => {
+    const query =
+      "SELECT \"limit\" FROM metrics WHERE note = 'LIMIT 100' /* LIMIT 100 */";
+
+    const result = service.validate(query, "sql", 25);
+
+    expect(result.normalizedQuery).toBe(`${query} LIMIT 25`);
+  });
+
+  it("appends a limit outside a trailing line comment", () => {
+    const query = "SELECT * FROM metrics -- LIMIT 100";
+
+    const result = service.validate(query, "sql", 25);
+
+    expect(result.normalizedQuery).toBe(`${query}\nLIMIT 25`);
+  });
+
   it("rejects SQL writes and multi-statement input", () => {
     expect(service.validate("DROP TABLE cpu", "sql").code).toBe(
       "not_read_only",


### PR DESCRIPTION
## Summary

Enforces the read-only result bound only at the outer SQL or InfluxQL statement level.

Nested `LIMIT` clauses no longer suppress the outer `LIMIT`, and an excessive outer bound is reduced without modifying nested clauses. Limits in strings, quoted identifiers, and comments are ignored. A newly added bound is placed after a trailing line comment.

## Root cause

The safety check used a global `LIMIT` regex, so a bound inside a subquery was treated as the result bound for the statement being executed.

## Validation

- `npm test`
- Scoped ESLint and Prettier checks
- Live Core 3.11 integration: 4 passed
- Live multi-node Enterprise 3.11 integration: 4 passed

Fixes #86.