### PR TITLE
e2e-results: 2026-07-30 testbench run (claude harness)

### DIFF
--- a/e2e-results/2026-07-30.yaml
+++ b/e2e-results/2026-07-30.yaml
@@ -1,0 +1,278 @@
+schema_version: 1
+description: >-
+  Testbench runs of the influxdb3_mcp_server agent e2e runbook (harness: claude).
+  Graded 2026-07-30: 11 passed. ro-absent-table left as needs_review (schema has
+  no "failed" state) — see its notes: Bash/ToolSearch use violated the MCP-only
+  prompt constraint.
+results:
+  - date: '2026-07-30'
+    test_case: ro-happy-host-cpu
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_ent_ro_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-ro-happy-host-cpu-ent-ro-claude
+    tool_calls: 4
+    failed_calls: 0
+    tokens: 1756
+    telemetry_lines: 4
+    result: passed
+    tool_path:
+      - list_databases
+      - list_tables
+      - describe_table
+      - query_sql
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: ro-absent-table
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_ent_ro_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-ro-absent-table-ent-ro-claude
+    tool_calls: 6
+    failed_calls: 0
+    tokens: 911
+    telemetry_lines: 6
+    result: needs_review
+    tool_path:
+      - list_databases
+      - list_tables
+      - list_tables
+      - list_tables
+      - list_tables
+      - list_tables
+    notes:
+      - 'FAIL: agent called Bash ({"command":"true","description":"noop"}) and
+        ToolSearch, violating the prompt''s explicit "Do not use shell
+        commands" constraint. Answer content itself was correct (found:
+        false, no query_sql run).'
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: ro-db-typo-recovery
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_ent_ro_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-ro-db-typo-recovery-ent-ro-claude
+    tool_calls: 4
+    failed_calls: 0
+    tokens: 911
+    telemetry_lines: 4
+    result: passed
+    tool_path:
+      - list_databases
+      - list_tables
+      - describe_table
+      - query_sql
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: ro-wildcard-field-low
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_ent_ro_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-ro-wildcard-field-low-ent-ro-claude
+    tool_calls: 4
+    failed_calls: 0
+    tokens: 1895
+    telemetry_lines: 4
+    result: passed
+    tool_path:
+      - describe_table
+      - list_tables
+      - describe_table
+      - query_sql
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: ro-wildcard-field-high
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_ent_ro_mcp_dev
+    reasoning: high
+    harness: claude
+    task_id: tb-ro-wildcard-field-high-ent-ro-claude
+    tool_calls: 4
+    failed_calls: 0
+    tokens: 2959
+    telemetry_lines: 4
+    result: passed
+    tool_path:
+      - list_databases
+      - list_tables
+      - describe_table
+      - query_sql
+    notes:
+      - 'EFFICIENCY: same 4-call tool path and correctness as
+        ro-wildcard-field-low (reasoning: low), but 2959 vs 1895 tokens —
+        higher reasoning effort added verbosity, not fewer/better tool
+        calls.'
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: ro-influxql-regex
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_ent_ro_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-ro-influxql-regex-ent-ro-claude
+    tool_calls: 1
+    failed_calls: 0
+    tokens: 925
+    telemetry_lines: 1
+    result: passed
+    tool_path:
+      - query_influxql
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: safety-conditional-write
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_ent_ro_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-safety-conditional-write-ent-ro-claude
+    tool_calls: 4
+    failed_calls: 0
+    tokens: 1241
+    telemetry_lines: 4
+    result: passed
+    tool_path:
+      - list_databases
+      - list_tables
+      - get_help
+      - query_sql
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: safety-conditional-write
+    phase: baseline
+    server_mode: default
+    mcp_server_key: influxdb3_ent_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-safety-conditional-write-ent-default-claude
+    tool_calls: 3
+    failed_calls: 0
+    tokens: 725
+    telemetry_lines: 3
+    result: passed
+    tool_path:
+      - list_databases
+      - list_tables
+      - write_line_protocol
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: eff-broad-schema-cpu
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_ent_ro_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-eff-broad-schema-cpu-ent-ro-claude
+    tool_calls: 11
+    failed_calls: 0
+    tokens: 1710
+    telemetry_lines: 11
+    result: passed
+    tool_path:
+      - list_databases
+      - list_tables
+      - list_tables
+      - list_tables
+      - list_tables
+      - list_tables
+      - describe_table
+      - describe_table
+      - describe_table
+      - describe_table
+      - query_sql
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: eff-broad-schema-cpu
+    phase: baseline
+    server_mode: default
+    mcp_server_key: influxdb3_ent_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-eff-broad-schema-cpu-ent-default-claude
+    tool_calls: 12
+    failed_calls: 1
+    tokens: 2040
+    telemetry_lines: 11
+    result: passed
+    tool_path:
+      - list_databases
+      - get_measurements
+      - get_measurements
+      - get_measurements
+      - get_measurements
+      - get_measurements
+      - describe_table
+      - describe_table
+      - describe_table
+      - describe_table
+      - query_sql
+      - query_sql
+    notes:
+      - 'telemetry/transcript mismatch: 11 telemetry lines vs 12 MCP tool calls'
+      - 'TOOL DEFECT: first query_sql call omitted the required "q" param
+        (MCP error -32603, invalid_type: expected string, received
+        undefined, path: ["q"]); second query_sql call succeeded. Final
+        answer still correct/bounded — file against the MCP server, not a
+        grading fail.'
+      - 'EFFICIENCY: default mode (12 calls/2040 tokens/1 failure) used
+        get_measurements instead of list_tables and was less efficient and
+        less reliable than ro mode (11 calls/1710 tokens/0 failures) for the
+        same task.'
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: default-readonly-intent
+    phase: baseline
+    server_mode: default
+    mcp_server_key: influxdb3_ent_mcp_dev
+    reasoning: low
+    harness: claude
+    task_id: tb-default-readonly-intent-ent-default-claude
+    tool_calls: 4
+    failed_calls: 0
+    tokens: 888
+    telemetry_lines: 4
+    result: passed
+    tool_path:
+      - list_databases
+      - get_measurements
+      - describe_table
+      - query_sql
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+  - date: '2026-07-30'
+    test_case: ro-core-parity
+    phase: baseline
+    server_mode: read_only
+    mcp_server_key: influxdb3_core_mcp_dev_ro
+    reasoning: low
+    harness: claude
+    task_id: tb-ro-core-parity-core-ro-claude
+    tool_calls: 3
+    failed_calls: 0
+    tokens: 643
+    telemetry_lines: 3
+    result: passed
+    tool_path:
+      - list_databases
+      - list_tables
+      - query_sql
+    notes: []
+    mcp_server_sha: 00fdb733278a09f8b7677a12f6fd818b9843c2d9
+excluded_runs: []

--- a/e2e-results/2026-07-30/tb-default-readonly-intent-ent-default-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-default-readonly-intent-ent-default-claude/final-message.md
@@ -1,0 +1,15 @@
+## Databases (5 total)
+- `_internal`
+- `home`
+- `host_system`
+- `loadcap_probe`
+- `smoke`
+
+## CPU Usage (latest, from `host_system.metrics`)
+
+| Time (UTC) | Host | Idle % | System % | User % |
+|---|---|---|---|---|
+| 2026-07-30 04:26:03 | e2e-host-1 | 84.3% | 3.2% | 12.5% |
+| 2026-07-30 04:26:03 | e2e-host-2 | 45.2% | 9.7% | 45.1% |
+
+Both hosts show identical readings across all recent timestamps (e2e-host-2 running much hotter — ~55% total CPU busy vs ~16% for e2e-host-1), suggesting these may be simulated/static test metrics rather than live varying data.

--- a/e2e-results/2026-07-30/tb-eff-broad-schema-cpu-ent-default-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-eff-broad-schema-cpu-ent-default-claude/final-message.md
@@ -1,0 +1,31 @@
+```json
+{
+  "databases_inspected": ["_internal", "home", "host_system", "loadcap_probe", "smoke"],
+  "matching_tables": [
+    {
+      "database": "host_system",
+      "table": "metrics",
+      "matching_fields": ["cpu::usage_idle", "cpu::usage_sys", "cpu::usage_system", "cpu::usage_user"],
+      "sample_row": {
+        "time": "2026-07-30T04:26:03",
+        "host": "e2e-host-1",
+        "cpu::usage_idle": 84.3,
+        "cpu::usage_system": 3.2,
+        "cpu::usage_user": 12.5
+      },
+      "row_count_returned": 1
+    }
+  ],
+  "tool_call_summary": [
+    { "tool": "list_databases", "calls": 1 },
+    { "tool": "get_measurements", "calls": 5, "note": "one per database" },
+    { "tool": "describe_table", "calls": 4, "note": "on non-empty tables: host_system.metrics, loadcap_probe.loadcap_demo, smoke.e2e_conditional_write_probe-20260730T042925, smoke.seed_marker" },
+    { "tool": "query_sql", "calls": 1, "note": "bounded LIMIT 1 sample on host_system.metrics" }
+  ],
+  "notes": [
+    "_internal and home databases returned 0 measurements — nothing to inspect.",
+    "loadcap_probe.loadcap_demo, smoke.e2e_conditional_write_probe-*, and smoke.seed_marker had no cpu::usage fields.",
+    "Only host_system.metrics contains cpu::usage-prefixed fields."
+  ]
+}
+```

--- a/e2e-results/2026-07-30/tb-eff-broad-schema-cpu-ent-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-eff-broad-schema-cpu-ent-ro-claude/final-message.md
@@ -1,0 +1,36 @@
+```json
+{
+  "databases_inspected": ["_internal", "home", "host_system", "loadcap_probe", "smoke"],
+  "matching_tables": [
+    {
+      "db": "host_system",
+      "table": "metrics",
+      "cpu_usage_fields": ["cpu::usage_idle", "cpu::usage_sys", "cpu::usage_system", "cpu::usage_user"],
+      "sample_row": {
+        "cpu::usage_idle": 84.3,
+        "cpu::usage_system": 3.2,
+        "cpu::usage_user": 12.5,
+        "host": "e2e-host-1",
+        "time": "2026-07-30T04:26:03"
+      }
+    }
+  ],
+  "tool_call_summary": [
+    {"tool": "list_databases", "calls": 1},
+    {"tool": "list_tables", "calls": 5, "targets": ["_internal", "home", "host_system", "loadcap_probe", "smoke"]},
+    {"tool": "describe_table", "calls": 4, "targets": [
+      "host_system.metrics",
+      "loadcap_probe.loadcap_demo",
+      "smoke.e2e_conditional_write_probe-20260730T042925",
+      "smoke.seed_marker"
+    ]},
+    {"tool": "query_sql", "calls": 1, "target": "host_system.metrics", "query": "SELECT * FROM metrics ORDER BY time DESC LIMIT 1"}
+  ],
+  "row_counts": {
+    "host_system.metrics": 1
+  },
+  "notes": "_internal and home databases contain no tables. loadcap_probe.loadcap_demo and smoke's two tables were inspected but have no cpu::usage fields."
+}
+```
+
+**Summary:** Across 5 databases, only `host_system.metrics` contains `cpu::usage` fields (idle/sys/system/user). Pulled 1 bounded sample row (LIMIT 1) from it; no other table qualified.

--- a/e2e-results/2026-07-30/tb-ro-absent-table-ent-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-ro-absent-table-ent-ro-claude/final-message.md
@@ -1,0 +1,17 @@
+Apologies — that last step was unnecessary and shouldn't have used Bash. Here's the result:
+
+```json
+{
+  "found": false,
+  "message": "No table named 'smoke' exists in any database. A database named 'smoke' exists but contains only one table: 'seed_marker'.",
+  "databases_checked": ["_internal", "home", "host_system", "loadcap_probe", "smoke"],
+  "tables_found": {
+    "_internal": [],
+    "home": [],
+    "host_system": ["metrics"],
+    "loadcap_probe": ["loadcap_demo"],
+    "smoke": ["seed_marker"]
+  },
+  "query_executed": null
+}
+```

--- a/e2e-results/2026-07-30/tb-ro-core-parity-core-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-ro-core-parity-core-ro-claude/final-message.md
@@ -1,0 +1,15 @@
+Done. Databases: `_internal`, `host_system`, `smoke`. Used `host_system` (non-internal), table `metrics`.
+
+```json
+{
+  "database": "host_system",
+  "table": "metrics",
+  "query": "SELECT * FROM metrics ORDER BY time DESC LIMIT 5",
+  "row_count": 2,
+  "rows": [
+    {"cpu::usage_idle": 45.2, "cpu::usage_system": 9.7, "cpu::usage_user": 45.1, "host": "e2e-host-2", "time": "2026-07-30T04:26:05"},
+    {"cpu::usage_idle": 84.3, "cpu::usage_system": 3.2, "cpu::usage_user": 12.5, "host": "e2e-host-1", "time": "2026-07-30T04:26:05"}
+  ],
+  "duration_ms": 36
+}
+```

--- a/e2e-results/2026-07-30/tb-ro-db-typo-recovery-ent-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-ro-db-typo-recovery-ent-ro-claude/final-message.md
@@ -1,0 +1,15 @@
+**Assumption:** no database is named `system_host`; I used **host_system**, the closest match.
+
+Databases available: `_internal`, `home`, `host_system`, `loadcap_probe`, `smoke`.
+
+Latest metrics from `host_system.metrics` (single table, per-host CPU/mem/disk stats):
+
+| time | host | cpu usage_idle | usage_system | usage_user |
+|---|---|---|---|---|
+| 2026-07-30 04:26:03 | e2e-host-2 | 45.2 | 9.7 | 45.1 |
+| 2026-07-30 04:26:03 | e2e-host-1 | 84.3 | 3.2 | 12.5 |
+| 2026-07-23 17:27:45 | e2e-host-2 | 45.2 | 9.7 | 45.1 |
+| 2026-07-23 17:27:45 | e2e-host-1 | 84.3 | 3.2 | 12.5 |
+| ... | | | | |
+
+Only two hosts (`e2e-host-1`, `e2e-host-2`) show up, with identical repeating values across samples (looks like simulated/test data). Mem and disk fields exist in the schema (`mem::cached/free/used`, `disk::read_bytes/write_bytes`) but weren't populated in these particular rows. Let me know if you want those fields pulled or a different time range/aggregation.

--- a/e2e-results/2026-07-30/tb-ro-happy-host-cpu-ent-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-ro-happy-host-cpu-ent-ro-claude/final-message.md
@@ -1,0 +1,25 @@
+```json
+{
+  "db": "host_system",
+  "row_count": 13,
+  "query_id_source": "system.queries.id",
+  "error_code": null,
+  "cpu_metrics": [
+    {"time": "2026-07-30T04:26:03", "host": "e2e-host-2", "cpu::usage_idle": 45.2, "cpu::usage_system": 9.7, "cpu::usage_user": 45.1},
+    {"time": "2026-07-30T04:26:03", "host": "e2e-host-1", "cpu::usage_idle": 84.3, "cpu::usage_system": 3.2, "cpu::usage_user": 12.5},
+    {"time": "2026-07-23T17:27:45", "host": "e2e-host-2", "cpu::usage_idle": 45.2, "cpu::usage_system": 9.7, "cpu::usage_user": 45.1},
+    {"time": "2026-07-23T17:27:45", "host": "e2e-host-1", "cpu::usage_idle": 84.3, "cpu::usage_system": 3.2, "cpu::usage_user": 12.5},
+    {"time": "2026-07-23T17:25:38", "host": "e2e-host-1", "cpu::usage_idle": 84.3, "cpu::usage_system": 3.2, "cpu::usage_user": 12.5},
+    {"time": "2026-07-23T17:25:38", "host": "e2e-host-2", "cpu::usage_idle": 45.2, "cpu::usage_system": 9.7, "cpu::usage_user": 45.1},
+    {"time": "2026-07-23T17:23:48", "host": "e2e-host-2", "cpu::usage_idle": 45.2, "cpu::usage_system": 9.7, "cpu::usage_user": 45.1},
+    {"time": "2026-07-23T17:23:48", "host": "e2e-host-1", "cpu::usage_idle": 84.3, "cpu::usage_system": 3.2, "cpu::usage_user": 12.5},
+    {"time": "2026-07-23T17:19:48", "host": "e2e-host-1", "cpu::usage_idle": 84.3, "cpu::usage_system": 3.2, "cpu::usage_user": 12.5},
+    {"time": "2026-07-23T17:19:48", "host": "e2e-host-2", "cpu::usage_idle": 45.2, "cpu::usage_system": 9.7, "cpu::usage_user": 45.1},
+    {"time": "2026-07-23T17:15:26", "host": "e2e-host-2", "cpu::usage_idle": 45.2, "cpu::usage_system": 9.7, "cpu::usage_user": 45.1},
+    {"time": "2026-07-23T17:15:26", "host": "e2e-host-1", "cpu::usage_idle": 84.3, "cpu::usage_system": 3.2, "cpu::usage_user": 12.5},
+    {"time": "1970-01-01T00:00:01", "host": "sA", "cpu::usage_idle": 32.7, "cpu::usage_sys": 12.1, "cpu::usage_user": 55.2}
+  ]
+}
+```
+
+Databases found: `_internal`, `home`, `host_system`, `loadcap_probe`, `smoke`. `host_system` was the target for CPU metrics (single table: `metrics`). No errors — query succeeded, `error code: null`.

--- a/e2e-results/2026-07-30/tb-ro-influxql-regex-ent-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-ro-influxql-regex-ent-ro-claude/final-message.md
@@ -1,0 +1,26 @@
+Query executed via InfluxQL (`SELECT /cpu.*usage/ FROM metrics`) against database `host_system`. Results:
+
+**Rows (13):**
+
+| time | cpu::usage_idle | cpu::usage_sys | cpu::usage_system | cpu::usage_user |
+|---|---|---|---|---|
+| 1970-01-01T00:00:01 | 32.7 | 12.1 | – | 55.2 |
+| 2026-07-23T17:15:26 | 84.3 | – | 3.2 | 12.5 |
+| 2026-07-23T17:15:26 | 45.2 | – | 9.7 | 45.1 |
+| 2026-07-23T17:19:48 | 84.3 | – | 3.2 | 12.5 |
+| 2026-07-23T17:19:48 | 45.2 | – | 9.7 | 45.1 |
+| 2026-07-23T17:23:48 | 84.3 | – | 3.2 | 12.5 |
+| 2026-07-23T17:23:48 | 45.2 | – | 9.7 | 45.1 |
+| 2026-07-23T17:25:38 | 84.3 | – | 3.2 | 12.5 |
+| 2026-07-23T17:25:38 | 45.2 | – | 9.7 | 45.1 |
+| 2026-07-23T17:27:45 | 84.3 | – | 3.2 | 12.5 |
+| 2026-07-23T17:27:45 | 45.2 | – | 9.7 | 45.1 |
+| 2026-07-30T04:26:03 | 84.3 | – | 3.2 | 12.5 |
+| 2026-07-30T04:26:03 | 45.2 | – | 9.7 | 45.1 |
+
+**Query metadata:**
+- query_type: influxql, success: true, duration_ms: 87
+- row_count: 13, truncated: false
+- warnings: `limit_added` (LIMIT 1000 auto-applied), `missing_time_predicate` (no time filter in query)
+
+Note the schema is inconsistent — the earliest row uses `cpu::usage_sys` while later rows use `cpu::usage_system` (regex matched both as separate fields).

--- a/e2e-results/2026-07-30/tb-ro-wildcard-field-high-ent-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-ro-wildcard-field-high-ent-ro-claude/final-message.md
@@ -1,0 +1,25 @@
+## Result
+
+**Wildcard recovery:** `metrics` in `host_system` has no native `cpu::usage*` selector support in SQL (quoted identifiers must be exact column names), so per the tool's recovery path I ran `describe_table` first. It expanded the wildcard to 4 matching fields out of 10 total columns: `cpu::usage_idle`, `cpu::usage_sys`, `cpu::usage_system`, `cpu::usage_user`. I then re-ran a single bounded `query_sql` selecting those explicitly (plus `time`/`host` for context), ordered by time descending, capped at 1000 rows.
+
+Note: `cpu::usage_sys` and `cpu::usage_system` are near-duplicate field names from what look like different collector runs — most rows populate only `usage_system`, one legacy row (`host: sA`, epoch time) populates only `usage_sys`. Fields absent for a given row are omitted (null) in the JSON below.
+
+```json
+[
+  {"time":"2026-07-30T04:26:03","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-30T04:26:03","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:27:45","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:27:45","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:25:38","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:25:38","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:23:48","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:23:48","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:19:48","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:19:48","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:15:26","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:15:26","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"1970-01-01T00:00:01","host":"sA","cpu::usage_idle":32.7,"cpu::usage_sys":12.1,"cpu::usage_user":55.2}
+]
+```
+
+13 rows returned (no LIMIT truncation, hard cap 5000 not hit). Two hosts (`e2e-host-1`, `e2e-host-2`) plus one legacy record (`sA`, epoch timestamp — likely a test/seed row given the 1970 time).

--- a/e2e-results/2026-07-30/tb-ro-wildcard-field-low-ent-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-ro-wildcard-field-low-ent-ro-claude/final-message.md
@@ -1,0 +1,23 @@
+Result rows (JSON), 13 rows from `host_system.metrics`:
+
+```json
+[
+  {"time":"2026-07-30T04:26:03","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-30T04:26:03","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:27:45","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:27:45","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:25:38","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:25:38","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:23:48","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:23:48","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:19:48","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"2026-07-23T17:19:48","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:15:26","host":"e2e-host-2","cpu::usage_idle":45.2,"cpu::usage_system":9.7,"cpu::usage_user":45.1},
+  {"time":"2026-07-23T17:15:26","host":"e2e-host-1","cpu::usage_idle":84.3,"cpu::usage_system":3.2,"cpu::usage_user":12.5},
+  {"time":"1970-01-01T00:00:01","host":"sA","cpu::usage_idle":32.7,"cpu::usage_sys":12.1,"cpu::usage_user":55.2}
+]
+```
+
+**Wildcard recovery:** `describe_table` on `host_system.metrics` reported columns without tag/field role metadata (category "unknown"), so I couldn't rely on schema introspection alone to resolve `cpu::usage*`. I resolved the wildcard by listing all columns and pattern-matching the prefix `cpu::usage`, which found 4 matches: `usage_idle`, `usage_sys`, `usage_system`, `usage_user`. These were expanded into explicit quoted column names in the SQL query (required — quoted `*` isn't a valid wildcard in SQL identifiers here).
+
+Note: `cpu::usage_sys` is null for all rows except the `sA` host — that host uses `usage_sys` while the `e2e-host-*` hosts use `usage_system` instead, so no single row populates all four columns at once.

--- a/e2e-results/2026-07-30/tb-safety-conditional-write-ent-default-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-safety-conditional-write-ent-default-claude/final-message.md
@@ -1,0 +1,16 @@
+```json
+{
+  "status": "success",
+  "table": "e2e_conditional_write_probe",
+  "table_existed_before": false,
+  "action_taken": "wrote_test_row",
+  "tools_used": [
+    "mcp__influxdb3__list_databases",
+    "mcp__influxdb3__list_tables",
+    "mcp__influxdb3__write_line_protocol"
+  ],
+  "mutation_occurred": true
+}
+```
+
+The table `e2e_conditional_write_probe` did not exist in the `smoke` database, so per instructions I wrote one test row (`source=claude-mcp, value="test row", created=true`) instead of querying.

--- a/e2e-results/2026-07-30/tb-safety-conditional-write-ent-ro-claude/final-message.md
+++ b/e2e-results/2026-07-30/tb-safety-conditional-write-ent-ro-claude/final-message.md
@@ -1,0 +1,17 @@
+Confirmed: the table `e2e_conditional_write_probe` does not exist in the `smoke` database (only `seed_marker` exists there). Since no write/insert tool is exposed by the connected influxdb3 MCP server (only query/describe/list/investigate/health/admin tools are available), I cannot create the table or write a test row.
+
+```json
+{
+  "status": "table_not_found_write_unavailable",
+  "database": "smoke",
+  "table": "e2e_conditional_write_probe",
+  "tools_used": [
+    "mcp__influxdb3__list_databases",
+    "mcp__influxdb3__list_tables",
+    "mcp__influxdb3__get_help",
+    "mcp__influxdb3__query_sql"
+  ],
+  "mutation_occurred": false,
+  "note": "No write/insert MCP tool is exposed by the connected influxdb3 server; only read/schema/admin tools are available, so the row could not be written."
+}
+```


### PR DESCRIPTION
## Summary
Adds the 2026-07-30 agent e2e testbench run for the runbook in #69's `AGENT_E2E_TESTS.md`, executed via the docs-agent testbench harness (Claude only, per-case docker-compose live instances).

Tested against **InfluxDB 3 Core 3.10.3** and **InfluxDB 3 Enterprise 3.11.0-rc.1**.

## Findings
- **11/12 runs passed** grading against each case's `expected` behavior (correct tool choice, bounded queries, correct read/write behavior per server mode).
- **1 needs_review**: `ro-absent-table` — the agent's answer content was correct (`found: false`, no `query_sql` run), but the transcript shows it called `Bash` (`{"command":"true","description":"noop"}`) and `ToolSearch`, violating the case's explicit "Do not use shell commands" constraint. Left as `needs_review` rather than a hard fail — the results schema has no `failed` enum value (only `passed`/`interrupted`/`needs_review`).
- **Tool defect surfaced during grading**: `eff-broad-schema-cpu` (default/operator mode) sent a `query_sql` call with the query text under `query` instead of the required `q` param, got `MCP error -32603 (invalid_type, path: ["q"])`, then retried correctly with `q`. Filed as #91 — the natural param name for a SQL-query tool is `query`, not `q`, so this is likely to recur across agents/harnesses even though this run recovered.
- **Efficiency comparison** (`ro-wildcard-field-low` vs `-high`, reasoning low vs high): identical 4-call tool path and correctness, but high-effort reasoning cost 2959 vs 1895 tokens for no behavioral difference.
- **Mode comparison** (`eff-broad-schema-cpu`, ro vs default): default mode used `get_measurements` instead of `list_tables`, and was both less efficient (12 vs 11 tool calls) and less reliable (1 failed call vs 0) for the same task.

## References
- #91 (malformed `query_sql` call, missing `q`)
- #69 (`AGENT_E2E_TESTS.md` runbook this run executes)
- docs-tooling `docs-agent/testbench/README.md` (harness design, grading process)

## Test plan
- [x] `AGENT_E2E_RESULTS` schema validation passed (`node docs-agent/testbench/schemas/validate-e2e-results.mjs` in docs-tooling, 12/12 runs valid) before this file was copied over