### PR TITLE
ci: print InfluxDB 3 Core version before starting the server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      - name: Print InfluxDB 3 Core version
+        run: docker run --rm influxdb:3-core influxdb3 --version
+
       - name: Start InfluxDB 3 Core
         run: |
           docker run -d --name influxdb3-core \


### PR DESCRIPTION
## Summary
Prints the InfluxDB 3 Core image version (`influxdb3 --version`) before the CI integration-test job starts the server, so a run's log shows which InfluxDB version it tested against.

## Test plan
- [x] CI runs this workflow directly; verify the new step's output shows a version line before "Start InfluxDB 3 Core"