### PR TITLE
ci: add release-publish workflow (npm + Docker Hub, environment-gated)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,69 @@
+name: Release publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+
+      - name: Verify tag matches package.json version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          pkg_version="v$(node -p "require('./package.json').version")"
+          if [ "$TAG_NAME" != "$pkg_version" ]; then
+            echo "Release tag $TAG_NAME does not match package.json version $pkg_version"
+            exit 1
+          fi
+
+      - name: npm publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  docker-publish:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    environment: docker-publish
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG_NAME#v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          push: true
+          tags: |
+            influxdata/influxdb3-mcp-server:${{ steps.tags.outputs.version }}
+            influxdata/influxdb3-mcp-server:latest


### PR DESCRIPTION
## Summary
Adds `.github/workflows/release-publish.yml`, triggered on `release: published`:

- **npm-publish job**: runs under the `npm-publish` GitHub Environment (required reviewer: jstirnaman). Verifies the release tag matches `package.json`'s version, then runs `npm publish` using an `NPM_TOKEN` secret.
- **docker-publish job**: runs under the `docker-publish` GitHub Environment (required reviewer: platform-services-team). Builds and pushes `influxdata/influxdb3-mcp-server:<version>` and `:latest` to Docker Hub using `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets.

Both environments already exist on this repo with their reviewer set (created via the GitHub API ahead of this PR). Neither job can run without an approval from its assigned reviewer(s) — this replaces the previously all-manual npm publish / Docker Hub publish steps with a gated, auditable workflow run.

## Before this can run for real
- [x] Add `NPM_TOKEN` secret to the `npm-publish` environment
- [ ] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the `docker-publish` environment

## Test plan
- [ ] Cut a test release (or dry-run via `workflow_dispatch` if added later) and confirm both jobs pause for environment approval before running
- [ ] Confirm npm-publish job fails closed if the release tag doesn't match `package.json` version