### PR TITLE
ci: don't clobber latest npm/Docker tags on prerelease publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -32,9 +32,15 @@ jobs:
           fi
 
       - name: npm publish
-        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          if [[ "$version" == *-* ]]; then
+            npm publish --tag prerelease
+          else
+            npm publish
+          fi
 
   docker-publish:
     name: Publish to Docker Hub
@@ -59,11 +65,18 @@ jobs:
         run: |
           version="${TAG_NAME#v}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          tags="influxdata/influxdb3-mcp-server:$version"
+          if [[ "$version" != *-* ]]; then
+            tags="$tags"$'\n'"influxdata/influxdb3-mcp-server:latest"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "$tags"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           push: true
-          tags: |
-            influxdata/influxdb3-mcp-server:${{ steps.tags.outputs.version }}
-            influxdata/influxdb3-mcp-server:latest
+          tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
## Summary
Follow-up to #95 (merged). That workflow's npm-publish and docker-publish jobs always moved `latest` regardless of version — a prerelease test tag like `v1.4.1-rc.1` would have overwritten the real `latest` dist-tag on npm and the real `latest` image on Docker Hub.

Fix:
- **npm**: prerelease versions (anything with a `-` in `package.json`'s version) publish under the `prerelease` dist-tag via `npm publish --tag prerelease`, instead of the default `latest`. Stable versions publish exactly as before.
- **Docker**: prerelease versions get only the `<version>` tag pushed; the `:latest` tag is only added for stable (non-prerelease) versions.

## Why this matters now
About to test the #95 workflow end-to-end with a `v1.4.1-rc.1`-style release tag. Without this fix, that test would have clobbered production `latest` on both registries.

## Test plan
- [ ] Cut a `v1.4.1-rc.1` test release, approve both environment gates, confirm:
  - npm: package published under `prerelease` dist-tag, `latest` dist-tag unchanged
  - Docker Hub: only `1.4.1-rc.1` tag pushed, `latest` tag unchanged