### PR TITLE
chore: bump version to 1.4.1-test.1 (test release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the official InfluxDB MCP Server will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1-test.1] - 2026-07-30
+
+### Changed
+
+- Test release: no functional changes. Cut to verify the environment-gated
+  release-publish workflow (#95, #96) publishes under the npm `prerelease`
+  dist-tag and skips the Docker `latest` tag, without moving `latest` on
+  either registry.
+
 ## [1.4.0] - 2026-07-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/influxdb3-mcp-server",
-  "version": "1.4.0",
+  "version": "1.4.1-test.1",
   "description": "Official InfluxDB MCP server for Model Context Protocol integration",
   "license": "(Apache-2.0 OR MIT)",
   "private": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,7 @@ export function loadConfig(): McpServerConfig {
     },
     server: {
       name: "influxdb-mcp-server",
-      version: "1.4.0",
+      version: "1.4.1-test.1",
     },
     tools: {
       profile:


### PR DESCRIPTION
## Summary
Version bump only, no functional changes. Cut to test the environment-gated release-publish workflow (#95, fixed for prerelease safety in #96) end-to-end with a real GitHub release.

Bumps `package.json`, `src/config.ts`, and adds the matching `CHANGELOG.md` entry (all three must match per the CI version-consistency check).

## Plan after merge
1. Tag `v1.4.1-test.1` on this merge commit, push the tag
2. `gh release create v1.4.1-test.1`
3. Approve the `npm-publish` and `docker-publish` environment gates
4. Verify: npm package published under the `prerelease` dist-tag (not `latest`); Docker Hub gets only the `1.4.1-test.1` tag (not `latest`)

## Test plan
- [x] CI version-consistency check passes with matching versions across all three files