### PR TITLE
fix: remove leading ./ from bin path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "./build/index.js",
   "bin": {
-    "influxdb-mcp-server": "./build/index.js"
+    "influxdb-mcp-server": "build/index.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- npm silently rewrites `bin["influxdb-mcp-server"]` from `./build/index.js` to `build/index.js` at publish time, printing a warning on every release.
- Removed the leading `./` so publish is warning-free.

## Test plan
- [x] `npm pkg fix` produces no further changes